### PR TITLE
Sprint 16 refactoring

### DIFF
--- a/src/main/java/com/wine/to/up/winestyle/parser/service/controller/KafkaController.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/controller/KafkaController.java
@@ -16,7 +16,7 @@ public class KafkaController {
 
     @PostMapping("/alcohol")
     public void sendAllalcoholToKafka() {
-        kafkaSenderService.sendAllalcohol();
+        kafkaSenderService.sendAllAlcohol();
     }
 
     @PostMapping("/alcohol/wines")

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/KafkaService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/KafkaService.java
@@ -1,7 +1,7 @@
 package com.wine.to.up.winestyle.parser.service.service;
 
 public interface KafkaService {
-    void sendAllalcohol();
+    void sendAllAlcohol();
     void sendAllWines();
     void sendAllSparkling();
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSender.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSender.java
@@ -1,0 +1,36 @@
+package com.wine.to.up.winestyle.parser.service.service.implementation.kafka;
+
+import com.wine.to.up.commonlib.messaging.KafkaMessageSender;
+import com.wine.to.up.parser.common.api.schema.ParserApi;
+import com.wine.to.up.winestyle.parser.service.components.WinestyleParserServiceMetricsCollector;
+import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
+import com.wine.to.up.winestyle.parser.service.service.Director;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KafkaSender {
+    private final KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
+    private final Director parserDirector;
+
+    private ParserApi.WineParsedEvent.Builder kafkaMessageBuilder = ParserApi.WineParsedEvent.newBuilder();
+    private Integer sended = 0;
+
+    public Integer sendAlcoholToKafka(Alcohol alcohol) {
+        try {
+            kafkaMessageSender.sendMessage(kafkaMessageBuilder
+                    .addWines(parserDirector
+                            .fillKafkaMessageBuilder(alcohol, AlcoholType.valueOf(alcohol.getType())))
+                    .build());
+            WinestyleParserServiceMetricsCollector.incPublished();
+            sended++;
+        } catch (Exception ex) {
+            log.error("Cannot send dataset to Kafka: id:{} {}", alcohol.getId(), alcohol.getType());
+        }
+        return sended;
+    }
+}

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderService.java
@@ -1,9 +1,5 @@
 package com.wine.to.up.winestyle.parser.service.service.implementation.kafka;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.wine.to.up.commonlib.messaging.KafkaMessageSender;
-import com.wine.to.up.parser.common.api.schema.ParserApi;
-import com.wine.to.up.winestyle.parser.service.components.WinestyleParserServiceMetricsCollector;
 import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
 import com.wine.to.up.winestyle.parser.service.service.Director;
 import com.wine.to.up.winestyle.parser.service.service.KafkaService;
@@ -11,120 +7,55 @@ import com.wine.to.up.winestyle.parser.service.service.RepositoryService;
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.*;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class KafkaSenderService implements KafkaService {
-    private final Director parserDirector;
     private final RepositoryService repositoryService;
-    private final KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
+    private final KafkaSender kafkaSender;
 
-    @Value("${spring.task.execution.pool.size}")
-    private int maxThreadCount;
-    @Value("${spring.jsoup.scraping.proxy-timeout.millis}")
-    private int timeout;
+    private Integer totalSended = 0;
 
-    private ExecutorService kafkaSendAllThreadPool;
-    private final ThreadFactory kafkaSendAllThreadFactory = new ThreadFactoryBuilder()
-            .setNameFormat("Kafka-Sender-%d")
-            .build();
-
-    private ExecutorService initPool(int maxThreadCount, ThreadFactory threadFactory) {
-        return Executors.newFixedThreadPool(maxThreadCount, threadFactory);
-    }
-
-    private void renewPools() {
-        if (kafkaSendAllThreadPool.isShutdown()) {
-            kafkaSendAllThreadPool = initPool(maxThreadCount, kafkaSendAllThreadFactory);
-        }
-    }
-
-    @PostConstruct
-    private void initPools() {
-        kafkaSendAllThreadPool = initPool(maxThreadCount, kafkaSendAllThreadFactory);
-    }
-
-    public void sendAllalcohol() {
-        renewPools();
+    public void sendAllAlcohol() {
         List<Alcohol> alcohol = repositoryService.getAll();
 
         LocalDateTime startSendingProcess = LocalDateTime.now();
         log.info("Start sending data of all alcohol to Kafka at {};", startSendingProcess);
 
-        int totalSended = 0;
-        try {
-            totalSended = sendalcohol(alcohol);
-        } catch (InterruptedException e) {
-            log.warn("The process of sending alcohol to kafka was interrupted!");
-        }
+        sendAlcohol(alcohol);
         logKafkaSended("alcohol", totalSended, startSendingProcess);
+        totalSended = 0;
     }
 
     public void sendAllWines() {
-        renewPools();
         List<Alcohol> wines = repositoryService.getAllWines();
 
         LocalDateTime startSendingProcess = LocalDateTime.now();
         log.info("Start sending data of all wines to Kafka at {};", startSendingProcess);
-
-        int totalSended = 0;
-        try {
-            totalSended = sendalcohol(wines);
-        } catch (InterruptedException e) {
-            log.warn("The process of sending wines to kafka was interrupted!");
-        }
+        sendAlcohol(wines);
         logKafkaSended(AlcoholType.WINE.toString(), totalSended, startSendingProcess);
+        totalSended = 0;
     }
 
     public void sendAllSparkling() {
-        renewPools();
         List<Alcohol> sparkling = repositoryService.getAllSparkling();
 
         LocalDateTime startSendingProcess = LocalDateTime.now();
         log.info("Start sending data of all sparkling to Kafka at {};", startSendingProcess);
 
-        int totalSended = 0;
-        try {
-            totalSended = sendalcohol(sparkling);
-        } catch (InterruptedException e) {
-            log.warn("The process of sending sparkling to kafka was interrupted!");
-        }
+        sendAlcohol(sparkling);
         logKafkaSended(AlcoholType.SPARKLING.toString(), totalSended, startSendingProcess);
+        totalSended = 0;
     }
 
-    private Integer sendalcohol(List<Alcohol> alcoholList) throws InterruptedException {
-        List<Future<Integer>> sendingFutures = new ArrayList<>();
-        Integer totalSended = 0;
-
-        try {
-            alcoholList.parallelStream().forEach(alcohol -> {
-                sendingFutures.add(kafkaSendAllThreadPool.submit(new KafkaSender(parserDirector, alcohol)));
-            });
-        } finally {
-            kafkaSendAllThreadPool.shutdown();
-            kafkaSendAllThreadPool.awaitTermination(timeout, TimeUnit.MILLISECONDS);
-
-            for (Future<Integer> future : sendingFutures) {
-                try {
-                    totalSended += future.get();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } catch (ExecutionException e) {
-                    log.error("Cannot execute sending alcohol to kafka");
-                }
-            }
-        }
-        return totalSended;
+    private void sendAlcohol(List<Alcohol> alcoholList) {
+        alcoholList.forEach(alcohol -> totalSended += kafkaSender.sendAlcoholToKafka(alcohol));
     }
 
     private void logKafkaSended(String alcoholType, Integer total, LocalDateTime startTime) {
@@ -139,33 +70,5 @@ public class KafkaSenderService implements KafkaService {
 
         log.info("Sending {} to kafka: in {} hours {} minutes {} seconds. Total sended {} alcohol",
                 alcoholType, hoursPassed, minutesPart, secondsPart, total);
-    }
-
-    @RequiredArgsConstructor
-    private class KafkaSender implements Callable<Integer> {
-        private final Director parserDirector;
-        private final Alcohol alcohol;
-
-        private ParserApi.WineParsedEvent.Builder kafkaMessageBuilder = ParserApi.WineParsedEvent.newBuilder();
-        private Integer sended = 0;
-
-        private Integer sendAlcoholToKafka() {
-            try {
-                kafkaMessageSender.sendMessage(kafkaMessageBuilder
-                        .addWines(parserDirector
-                                .fillKafkaMessageBuilder(alcohol, AlcoholType.valueOf(alcohol.getType())))
-                        .build());
-                WinestyleParserServiceMetricsCollector.incPublished();
-                sended++;
-            } catch (Exception ex) {
-                log.error("Cannot send dataset to Kafka: id:{} {}", alcohol.getId(), alcohol.getType());
-            }
-            return sended;
-        }
-
-        @Override
-        public Integer call() throws Exception {
-            return sendAlcoholToKafka();
-        }
     }
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Optional;
 
-@Service
+@Service("ParserDirector")
 public class ParserDirector implements Director {
     @Getter
     private final ParserApi.Wine.Builder kafkaMessageBuilder = ParserApi.Wine.newBuilder();

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserService.java
@@ -2,47 +2,26 @@ package com.wine.to.up.winestyle.parser.service.service.implementation.parser;
 
 import com.wine.to.up.commonlib.annotations.InjectEventLogger;
 import com.wine.to.up.commonlib.logging.EventLogger;
-import com.wine.to.up.commonlib.messaging.KafkaMessageSender;
-import com.wine.to.up.parser.common.api.schema.ParserApi;
 import com.wine.to.up.winestyle.parser.service.components.WinestyleParserServiceMetricsCollector;
-import com.wine.to.up.winestyle.parser.service.controller.exception.NoEntityException;
-import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
 import com.wine.to.up.winestyle.parser.service.logging.NotableEvents;
-import com.wine.to.up.winestyle.parser.service.service.Director;
-import com.wine.to.up.winestyle.parser.service.service.Parser;
-import com.wine.to.up.winestyle.parser.service.service.RepositoryService;
 import com.wine.to.up.winestyle.parser.service.service.WinestyleParserService;
 import com.wine.to.up.winestyle.parser.service.service.implementation.document.Scraper;
-import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ApplicationContextLocator;
-import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.MainPageSegmentor;
-import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ProductBlockSegmentor;
-import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ProductPageSegmentor;
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import com.wine.to.up.winestyle.parser.service.service.implementation.parser.job.MainJob;
 import io.micrometer.core.annotation.Timed;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.time.DayOfWeek;
-import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Supplier;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ParserService implements WinestyleParserService {
-    private final KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
-    private final RepositoryService repositoryService;
+    private final MainJob mainJob;
     private final Scraper scraper;
 
     @Setter
@@ -52,16 +31,12 @@ public class ParserService implements WinestyleParserService {
 
     private static final String PARSING_PROCESS_DURATION_SUMMARY = "parsing_process_duration";
 
-    @Value("${spring.jsoup.scraping.interval.millis}")
-    private int timeout;
     @Value("${spring.jsoup.pagination.css.query.main-bottom}")
     private String paginationElementCssQuery;
 
     @SuppressWarnings("unused")
     @InjectEventLogger
     private EventLogger eventLogger;
-
-    private int parsed = 0;
 
     @Timed(PARSING_PROCESS_DURATION_SUMMARY)
     @Override
@@ -85,7 +60,7 @@ public class ParserService implements WinestyleParserService {
                 log.info("Parsing: {}", currentDoc.location());
 
                 try {
-                    Integer currentUnparsed = new MainJob(currentDoc, start, scraper).get();
+                    Integer currentUnparsed = mainJob.get(currentDoc, alcoholType, mainPageUrl, start);
                     unparsed += currentUnparsed;
                 }
                 catch (Exception e) {
@@ -108,7 +83,7 @@ public class ParserService implements WinestyleParserService {
 
             log.debug("Unparsed {}: {}", alcoholType, unparsed);
 
-            parsed = 0;
+            mainJob.setParsed(0);
         }
     }
 
@@ -118,180 +93,6 @@ public class ParserService implements WinestyleParserService {
         } catch (NullPointerException ex) {
             log.info("{} does not contain a pagination element: the number of pages is set to 1", doc.location());
             return 1;
-        }
-    }
-
-    @RequiredArgsConstructor
-    private class MainJob implements Supplier<Integer> {
-        private final Document currentDoc;
-        private final LocalDateTime start;
-        private final Scraper scraper;
-        private final MainPageSegmentor mainPageSegmentor = ApplicationContextLocator.getApplicationContext().getBean(MainPageSegmentor.class);
-
-        /**
-         * Парсер страницы с позициями
-         */
-        @SneakyThrows
-        @Override
-        public Integer get() {
-            LocalDateTime mainParsingStart = LocalDateTime.now();
-            Elements productElements = mainPageSegmentor.extractProductElements(currentDoc);
-
-            int parsedNow = 0;
-            int unparsed = 0;
-
-            List<Pair<ProductJob, String>> parsingJobs = new ArrayList<>();
-            ProductJob productJob;
-            String productUrl;
-
-            for (Element productElement : productElements) {
-                productJob = new ProductJob(productElement, scraper);
-                try {
-                    productUrl = productJob.new ProductUrlJob().get();
-                } catch (Exception e) {
-                    log.error("Critical error during execution of url from product block {}", productElement.html());
-                    continue;
-                }
-                parsingJobs.add(new Pair<>(productJob, productUrl));
-            }
-
-            Pair<ProductJob, String> currentPair;
-            Alcohol result;
-
-            for (int i = 0; i < productElements.size(); i++) {
-                currentPair = parsingJobs.get(i);
-                productUrl = currentPair.getUrl();
-                try {
-                    result = currentPair.getParsingJob().get();
-                    eventLogger.info(NotableEvents.I_WINE_DETAILS_PARSED, productUrl, result);
-                    parsedNow += 1;
-                } catch (Exception e) {
-                    eventLogger.warn(NotableEvents.W_WINE_DETAILS_PARSING_FAILED, productUrl);
-                    unparsed += 1;
-                }
-                Thread.sleep(timeout);
-            }
-
-            WinestyleParserServiceMetricsCollector.sumPageParsingDuration(mainParsingStart, LocalDateTime.now());
-
-            eventLogger.info(NotableEvents.I_WINE_PAGE_PARSED, currentDoc.location());
-
-            countParsed(parsedNow);
-
-            logParsed(alcoholType, start);
-
-            return unparsed;
-        }
-
-        private synchronized void countParsed(int parsedNow) {
-            parsed += parsedNow;
-        }
-
-        private void logParsed(AlcoholType alcoholType, LocalDateTime start) {
-            long hoursPassed;
-            long minutesPart;
-            long secondsPart;
-            Duration timePassed = java.time.Duration.between((start), LocalDateTime.now());
-
-            hoursPassed = timePassed.toHours();
-            minutesPart = (timePassed.toMinutes() - hoursPassed * 60);
-            secondsPart = (timePassed.toSeconds() - hoursPassed * 3600 - minutesPart * 60);
-
-            log.info("Parsing of {}: {} in {} hours {} minutes {} seconds ({} entities per second)",
-                    alcoholType, parsed, hoursPassed, minutesPart, secondsPart, parsed / (double) timePassed.toSeconds());
-        }
-
-        @RequiredArgsConstructor
-        private class Pair<L, R> {
-            @Getter
-            private final L parsingJob;
-            @Getter
-            private final R url;
-        }
-    }
-
-    @RequiredArgsConstructor
-    private class ProductJob implements Supplier<Alcohol> {
-        private final Element productElement;
-        private final Scraper scraper;
-        private final Director director = new ParserDirector();
-        private final ProductBlockSegmentor productBlockSegmentor = ApplicationContextLocator.getApplicationContext().getBean(ProductBlockSegmentor.class);
-        private final Parser parser = ApplicationContextLocator.getApplicationContext().getBean(Parser.class);
-        private String productUrl;
-
-        @Override
-        public Alcohol get() {
-            log.info("Now parsing url: {}", productUrl);
-
-            LocalDateTime productParsingStart = LocalDateTime.now();
-
-            Alcohol alcohol;
-            ParserApi.WineParsedEvent.Builder kafkaMessageBuilder = ParserApi.WineParsedEvent.newBuilder().setShopLink(mainPageUrl);
-
-            try {
-                alcohol = repositoryService.getByUrl(productUrl);
-
-                if (LocalDateTime.now().getDayOfWeek() == DayOfWeek.MONDAY) {
-                    alcohol = parseProduct(kafkaMessageBuilder);
-                } else {
-                    alcohol.setPrice(parser.parsePrice().orElse(null));
-                    alcohol.setRating(parser.parseWinestyleRating().orElse(null));
-                    repositoryService.add(alcohol);
-                    kafkaMessageSender.sendMessage(kafkaMessageBuilder.addWines(director.fillKafkaMessageBuilder(alcohol, alcoholType)).build());
-                }
-            } catch (NoEntityException ex) {
-                alcohol = parseProduct(kafkaMessageBuilder);
-            }
-
-            WinestyleParserServiceMetricsCollector.sumDetailsParsingDuration(productParsingStart, LocalDateTime.now());
-            WinestyleParserServiceMetricsCollector.incPublished();
-
-            return alcohol;
-        }
-
-        private Alcohol parseProduct(ParserApi.WineParsedEvent.Builder kafkaMessageBuilder) {
-            Document product = null;
-
-            LocalDateTime detailsFetchingStart = LocalDateTime.now();
-            try {
-                product = scraper.getJsoupDocument(mainPageUrl + productUrl);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            WinestyleParserServiceMetricsCollector.sumDetailsFetchingDuration(detailsFetchingStart, LocalDateTime.now());
-
-            prepareParsingService(product);
-
-            Alcohol alcohol = director.makeAlcohol(parser, mainPageUrl, productUrl, alcoholType);
-
-            repositoryService.add(alcohol);
-
-            kafkaMessageSender.sendMessage(kafkaMessageBuilder.addWines(director.getKafkaMessageBuilder()).build());
-
-            return alcohol;
-        }
-
-        private void prepareParsingService(Document doc) {
-            ProductPageSegmentor productPageSegmentor = ApplicationContextLocator.getApplicationContext().getBean(ProductPageSegmentor.class);
-
-            Element productPageMainContent = productPageSegmentor.extractProductPageMainContent(doc);
-
-            parser.setListDescription(productBlockSegmentor.extractListDescription(productElement));
-            parser.setLeftBlock(productPageSegmentor.extractLeftBlock(productPageMainContent));
-            parser.setArticlesBlock(productPageSegmentor.extractArticlesBlock(productPageMainContent));
-            parser.setDescriptionBlock(productPageSegmentor.extractDescriptionBlock(productPageMainContent));
-        }
-
-        @RequiredArgsConstructor
-        private class ProductUrlJob implements Supplier<String> {
-            @Override
-            public String get() {
-                parser.setProductBlock(productElement);
-                parser.setInfoContainer(productBlockSegmentor.extractInfoContainer(productElement));
-
-                productUrl = parser.parseUrl();
-                return productUrl;
-            }
         }
     }
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/MainJob.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/MainJob.java
@@ -1,0 +1,101 @@
+package com.wine.to.up.winestyle.parser.service.service.implementation.parser.job;
+
+import com.wine.to.up.commonlib.annotations.InjectEventLogger;
+import com.wine.to.up.commonlib.logging.EventLogger;
+import com.wine.to.up.winestyle.parser.service.components.WinestyleParserServiceMetricsCollector;
+import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
+import com.wine.to.up.winestyle.parser.service.logging.NotableEvents;
+import com.wine.to.up.winestyle.parser.service.service.Parser;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.MainPageSegmentor;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class MainJob {
+    private final Parser parser;
+    private final ProductJob productJob;
+    private final ProductUrlJob productUrlJob;
+    private final MainPageSegmentor mainPageSegmentor;
+
+    @Value("${spring.jsoup.scraping.interval.millis}")
+    private int timeout;
+    @Setter
+    private int parsed = 0;
+
+    @SuppressWarnings("unused")
+    @InjectEventLogger
+    private EventLogger eventLogger;
+
+    /**
+     * Парсер страницы с позициями
+     */
+    @SneakyThrows
+    public Integer get(Document currentDoc, AlcoholType alcoholType, String mainPageUrl, LocalDateTime start) {
+        LocalDateTime mainParsingStart = LocalDateTime.now();
+        Elements productElements = mainPageSegmentor.extractProductElements(currentDoc);
+
+        int parsedNow = 0;
+        int unparsed = 0;
+
+        String productUrl;
+        Alcohol result;
+
+        for (Element productElement : productElements) {
+            try {
+                productUrl = productUrlJob.get(parser, productElement);
+                try {
+                    result = productJob.getParsedAlcohol(parser, mainPageUrl, productUrl, productElement, alcoholType);
+                    eventLogger.info(NotableEvents.I_WINE_DETAILS_PARSED, productUrl, result);
+                    parsedNow += 1;
+                } catch (Exception e) {
+                    eventLogger.warn(NotableEvents.W_WINE_DETAILS_PARSING_FAILED, productUrl);
+                    unparsed += 1;
+                }
+                Thread.sleep(timeout);
+            } catch (Exception e) {
+                log.error("Critical error during execution of url from product block {}", productElement.html());
+            }
+        }
+
+        WinestyleParserServiceMetricsCollector.sumPageParsingDuration(mainParsingStart, LocalDateTime.now());
+
+        eventLogger.info(NotableEvents.I_WINE_PAGE_PARSED, currentDoc.location());
+
+        countParsed(parsedNow);
+
+        logParsed(alcoholType, start);
+
+        return unparsed;
+    }
+
+    private synchronized void countParsed(int parsedNow) {
+        parsed += parsedNow;
+    }
+
+    private void logParsed(AlcoholType alcoholType, LocalDateTime start) {
+        long hoursPassed;
+        long minutesPart;
+        long secondsPart;
+        Duration timePassed = java.time.Duration.between((start), LocalDateTime.now());
+
+        hoursPassed = timePassed.toHours();
+        minutesPart = (timePassed.toMinutes() - hoursPassed * 60);
+        secondsPart = (timePassed.toSeconds() - hoursPassed * 3600 - minutesPart * 60);
+
+        log.info("Parsing of {}: {} in {} hours {} minutes {} seconds ({} entities per second)",
+                alcoholType, parsed, hoursPassed, minutesPart, secondsPart, parsed / (double) timePassed.toSeconds());
+    }
+}

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductJob.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductJob.java
@@ -1,0 +1,109 @@
+package com.wine.to.up.winestyle.parser.service.service.implementation.parser.job;
+
+import com.wine.to.up.commonlib.messaging.KafkaMessageSender;
+import com.wine.to.up.parser.common.api.schema.ParserApi;
+import com.wine.to.up.winestyle.parser.service.components.WinestyleParserServiceMetricsCollector;
+import com.wine.to.up.winestyle.parser.service.controller.exception.NoEntityException;
+import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
+import com.wine.to.up.winestyle.parser.service.service.Director;
+import com.wine.to.up.winestyle.parser.service.service.Parser;
+import com.wine.to.up.winestyle.parser.service.service.RepositoryService;
+import com.wine.to.up.winestyle.parser.service.service.implementation.document.Scraper;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ApplicationContextLocator;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ProductBlockSegmentor;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ProductPageSegmentor;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import com.wine.to.up.winestyle.parser.service.service.implementation.parser.ParserDirector;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ProductJob {
+    @Qualifier("ParserDirector") private final Director director;
+    private final KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
+    private final RepositoryService repositoryService;
+    private final Scraper scraper;
+    private final ProductBlockSegmentor productBlockSegmentor;
+    private final ProductPageSegmentor productPageSegmentor;
+
+    private String mainPageUrl;
+    private String productUrl;
+    private AlcoholType alcoholType;
+    private Parser parser;
+
+    public Alcohol getParsedAlcohol(Parser parser, String mainPageUrl, String productUrl, Element productElement, AlcoholType alcoholType) {
+        this.mainPageUrl = mainPageUrl;
+        this.productUrl = productUrl;
+        this.alcoholType = alcoholType;
+        this.parser = parser;
+
+        log.info("Now parsing url: {}", productUrl);
+
+        LocalDateTime productParsingStart = LocalDateTime.now();
+
+        Alcohol alcohol;
+        ParserApi.WineParsedEvent.Builder kafkaMessageBuilder = ParserApi.WineParsedEvent.newBuilder().setShopLink(mainPageUrl);
+
+        try {
+            alcohol = repositoryService.getByUrl(productUrl);
+
+            if (LocalDateTime.now().getDayOfWeek() == DayOfWeek.MONDAY) {
+                alcohol = parseProduct(productElement, kafkaMessageBuilder);
+            } else {
+                alcohol.setPrice(parser.parsePrice().orElse(null));
+                alcohol.setRating(parser.parseWinestyleRating().orElse(null));
+                repositoryService.add(alcohol);
+                kafkaMessageSender.sendMessage(kafkaMessageBuilder.addWines(director.fillKafkaMessageBuilder(alcohol, alcoholType)).build());
+            }
+        } catch (NoEntityException ex) {
+            alcohol = parseProduct(productElement, kafkaMessageBuilder);
+        }
+
+        WinestyleParserServiceMetricsCollector.sumDetailsParsingDuration(productParsingStart, LocalDateTime.now());
+        WinestyleParserServiceMetricsCollector.incPublished();
+
+        return alcohol;
+    }
+
+    private Alcohol parseProduct(Element productElement, ParserApi.WineParsedEvent.Builder kafkaMessageBuilder) {
+        Document product = null;
+
+        LocalDateTime detailsFetchingStart = LocalDateTime.now();
+        try {
+            product = scraper.getJsoupDocument(mainPageUrl + productUrl);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        WinestyleParserServiceMetricsCollector.sumDetailsFetchingDuration(detailsFetchingStart, LocalDateTime.now());
+
+        prepareParsingService(product, productElement);
+
+        Alcohol alcohol = director.makeAlcohol(parser, mainPageUrl, productUrl, alcoholType);
+
+        repositoryService.add(alcohol);
+
+        kafkaMessageSender.sendMessage(kafkaMessageBuilder.addWines(director.getKafkaMessageBuilder()).build());
+
+        return alcohol;
+    }
+
+    private void prepareParsingService(Document doc, Element productElement) {
+
+        Element productPageMainContent = productPageSegmentor.extractProductPageMainContent(doc);
+
+        parser.setListDescription(productBlockSegmentor.extractListDescription(productElement));
+        parser.setLeftBlock(productPageSegmentor.extractLeftBlock(productPageMainContent));
+        parser.setArticlesBlock(productPageSegmentor.extractArticlesBlock(productPageMainContent));
+        parser.setDescriptionBlock(productPageSegmentor.extractDescriptionBlock(productPageMainContent));
+    }
+}

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductUrlJob.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductUrlJob.java
@@ -1,0 +1,19 @@
+package com.wine.to.up.winestyle.parser.service.service.implementation.parser.job;
+
+import com.wine.to.up.winestyle.parser.service.service.Parser;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ProductBlockSegmentor;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ProductUrlJob {
+    private final ProductBlockSegmentor productBlockSegmentor;
+
+    public String get(Parser parser, Element productElement) {
+        parser.setProductBlock(productElement);
+        parser.setInfoContainer(productBlockSegmentor.extractInfoContainer(productElement));
+        return parser.parseUrl();
+    }
+}

--- a/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserServiceTest.java
+++ b/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserServiceTest.java
@@ -38,43 +38,19 @@ class ParserServiceTest {
     @MockBean
     private ApplicationContextLocator applicationContextLocator = mock(ApplicationContextLocator.class);
 
-    @Mock
-    ExecutorService mainPageParsingThreadPool;
-    @Spy
-    ExecutorService productPageParsingThreadPool;
-    @Spy
-    ExecutorService urlFetchingThreadPool;
-
-    ThreadFactory mainPageParsingThreadFactory = new ThreadFactoryBuilder()
-            .setNameFormat("Main_parser-%d")
-            .build();
-    ThreadFactory productPageParsingThreadFactory = new ThreadFactoryBuilder()
-            .setNameFormat("Prod_parser-%d")
-            .build();
-    ThreadFactory urlFetchingThreadFactory = new ThreadFactoryBuilder()
-            .setNameFormat("Url_fetching-%d")
-            .build();
-
     String htmlPage = "div id=\"CatalogPagingBottom\"" +
-            "<li>1</li>" +
+            "<li>2</li>" +
             "</div>";
 
     @BeforeEach
-    void setUp() throws InterruptedException, ExecutionException {
+    void setUp() throws InterruptedException {
         MockitoAnnotations.initMocks(this);
-        ReflectionTestUtils.setField(parserService, "maxThreadCount", 2);
         ReflectionTestUtils.setField(parserService, "timeout", 10);
         ReflectionTestUtils.setField(parserService, "paginationElementCssQuery", "#CatalogPagingBottom li:last-of-type");
 
-        mainPageParsingThreadPool = spy(ExecutorService.class);
-        productPageParsingThreadPool = spy(Executors.newFixedThreadPool(2, productPageParsingThreadFactory));
-        urlFetchingThreadPool = spy(Executors.newFixedThreadPool(2, urlFetchingThreadFactory));
-        ReflectionTestUtils.setField(parserService, "mainPageParsingThreadPool", mainPageParsingThreadPool);
-        ReflectionTestUtils.setField(parserService, "productPageParsingThreadPool", productPageParsingThreadPool);
-        ReflectionTestUtils.setField(parserService, "urlFetchingThreadPool", urlFetchingThreadPool);
-
         Document document = Jsoup.parse(htmlPage);
         Mockito.when(scraper.getJsoupDocument("test/test")).thenReturn(document);
+        Mockito.when(scraper.getJsoupDocument("test/test?page=2")).thenReturn(document);
     }
 
     @Test
@@ -86,7 +62,7 @@ class ParserServiceTest {
         } catch (NullPointerException ex) {
             log.warn("Cannot execute MainJob inner class. Ok.");
         }
-        Mockito.verify(mainPageParsingThreadPool, times(1)).shutdownNow();
+        Mockito.verify(scraper, times(1)).getJsoupDocument("test/test");
     }
 
     @Test

--- a/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserServiceTest.java
+++ b/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserServiceTest.java
@@ -30,13 +30,7 @@ class ParserServiceTest {
     @InjectMocks
     private ParserService parserService;
     @Mock
-    private KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
-    @Mock
-    private RepositoryService repositoryService;
-    @Mock
     private Scraper scraper;
-    @MockBean
-    private ApplicationContextLocator applicationContextLocator = mock(ApplicationContextLocator.class);
 
     String htmlPage = "div id=\"CatalogPagingBottom\"" +
             "<li>2</li>" +
@@ -45,7 +39,6 @@ class ParserServiceTest {
     @BeforeEach
     void setUp() throws InterruptedException {
         MockitoAnnotations.initMocks(this);
-        ReflectionTestUtils.setField(parserService, "timeout", 10);
         ReflectionTestUtils.setField(parserService, "paginationElementCssQuery", "#CatalogPagingBottom li:last-of-type");
 
         Document document = Jsoup.parse(htmlPage);


### PR DESCRIPTION
Сделал рефакторинг Parser Service после отказа от многопоточности: 
- Вынес внутренние классы для возможности дальнейшего тестирования;
- Убрал лишние обертки, которые предназначались для многопоточности (напр. Pair<ProductJob, ProductUrl>());
- Убрал вызов бинов через ApplicationContextLocator.