### PR TITLE
Sprint 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <current-version>0.6.0</current-version>
 
         <service.commonlib.version>0.2.3-SNAPSHOT</service.commonlib.version>
-        <parser.common.api.version>0.2.3-SNAPSHOT</parser.common.api.version>
+        <parser.common.api.version>0.2.5-SNAPSHOT</parser.common.api.version>
 
         <jsoup.version>1.13.1</jsoup.version>
         <opencsv.version>5.2</opencsv.version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
             <version>${parser.common.api.version}</version>
         </dependency>
 
+        <!-- Eureka -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+
         <!-- testing dependency -->
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/ServiceApplication.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/ServiceApplication.java
@@ -2,6 +2,7 @@ package com.wine.to.up.winestyle.parser.service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -10,6 +11,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @ComponentScan("com.wine.to.up")
 @EnableSwagger2
 @EnableScheduling
+@EnableDiscoveryClient
 public class ServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(ServiceApplication.class, args);

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/controller/KafkaController.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/controller/KafkaController.java
@@ -16,7 +16,7 @@ public class KafkaController {
 
     @PostMapping("/alcohol")
     public void sendAllalcoholToKafka() {
-        kafkaSenderService.sendAllalcohol();
+        kafkaSenderService.sendAllAlcohol();
     }
 
     @PostMapping("/alcohol/wines")

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/domain/entity/Alcohol.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/domain/entity/Alcohol.java
@@ -1,5 +1,6 @@
 package com.wine.to.up.winestyle.parser.service.domain.entity;
 
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.City;
 import lombok.*;
 
 import javax.persistence.*;
@@ -17,96 +18,153 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class Alcohol {
 
-    /**Поле id - уникальный номер*/
+    /**
+     * Поле id - уникальный номер
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /**Поле type - тип (Вино/Шампанское/Игристое)*/
-    @Column(columnDefinition = "varchar(25)")
+    /**
+     * Поле type - тип (Вино/Шампанское/Игристое)
+     */
+    @Column(columnDefinition = "VARCHAR(25)")
     @NotNull
     private String type;
 
-    /**Поле name - название напитка*/
-    @Column(columnDefinition = "varchar(130)")
+    /**
+     * Поле name - название напитка
+     */
+    @Column(columnDefinition = "VARCHAR(130)")
     @NotNull
     private String name;
 
-    /**Поле url - ссылка на страницу напитка*/
-    @Column(columnDefinition = "varchar(140)")
+    /**
+     * Поле url - ссылка на страницу напитка
+     */
+    @Column(columnDefinition = "VARCHAR(140)")
     @NotNull
     private String url;
 
-    /**Поле imageUrl - ссылка на изображение напитка*/
-    @Column(columnDefinition = "varchar(65)")
+    /**
+     * Поле city - enum с указанием города, откуда была спаршена позиция
+     */
+    @Column(columnDefinition = "VARCHAR(20)")
+    @Enumerated(EnumType.STRING)
+    private City city;
+
+    /**
+     * Поле imageUrl - ссылка на изображение напитка
+     */
+    @Column(columnDefinition = "VARCHAR(65)")
     private String imageUrl;
 
-    /**Поле image - изображение напитка*/
+    /**
+     * Поле image - изображение напитка
+     */
     @OneToOne(mappedBy = "alcohol", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Image image;
 
-    /**Поле cropYear - год сбора*/
+    /**
+     * Поле cropYear - год сбора
+     */
     @Column
     private Integer cropYear;
 
-    /**Поле manufacturer - производитель*/
-    @Column(columnDefinition = "varchar(65)")
+    /**
+     * Поле manufacturer - производитель
+     */
+    @Column(columnDefinition = "VARCHAR(65)")
     private String manufacturer;
 
-    /**Поле brand - бренд*/
-    @Column(columnDefinition = "varchar(50)")
+    /**
+     * Поле brand - бренд
+     */
+    @Column(columnDefinition = "VARCHAR(50)")
     private String brand;
 
-    /**Поле color - оттенок*/
-    @Column(columnDefinition = "varchar(10)")
+    /**
+     * Поле color - оттенок
+     */
+    @Column(columnDefinition = "VARCHAR(10)")
     private String color;
 
-    /**Поле country - страна происхождения винограда*/
-    @Column(columnDefinition = "varchar(15)")
+    /**
+     * Поле country - страна происхождения винограда
+     */
+    @Column(columnDefinition = "VARCHAR(15)")
     private String country;
 
-    /**Поле region - регион винограда*/
-    @Column(columnDefinition = "varchar(70)")
+    /**
+     * Поле region - регион винограда
+     */
+    @Column(columnDefinition = "VARCHAR(70)")
     private String region;
 
-    /**Поле volume - обьем*/
+    /**
+     * Поле volume - обьем
+     */
     @Column
     private Float volume;
 
-    /**Поле strength - крепость*/
-    @Column(columnDefinition = "varchar(25)")
+    /**
+     * Поле strength - крепость
+     */
+    @Column(columnDefinition = "VARCHAR(25)")
     private Float strength;
 
-    /**Поле sugar - сладость/сухость*/
-    @Column(columnDefinition = "varchar(20)")
+    /**
+     * Поле sugar - сладость/сухость
+     */
+    @Column(columnDefinition = "VARCHAR(20)")
     private String sugar;
 
-    /**Поле price - цена в рублях*/
+    /**
+     * Поле price - цена в рублях
+     */
     @Setter
     @Column
     private Float price;
 
-    /**Поле grape - сорт винограда*/
-    @Column(columnDefinition = "varchar(125)")
+    /**
+     * Поле grape - сорт винограда
+     */
+    @Column(columnDefinition = "VARCHAR(125)")
     private String grape;
 
-    /**Поле taste - вкус*/
+    /**
+     * Поле availability - наличие в продаже
+     */
+    @Column(columnDefinition = "BOOL")
+    private Boolean availability;
+
+    /**
+     * Поле taste - вкус
+     */
     @Column(columnDefinition = "TEXT")
     private String taste;
 
-    /**Поле aroma - аромат*/
+    /**
+     * Поле aroma - аромат
+     */
     @Column(columnDefinition = "TEXT")
     private String aroma;
 
-    /**Поле foodPairing - сочетания с блюдами*/
+    /**
+     * Поле foodPairing - сочетания с блюдами
+     */
     @Column(columnDefinition = "TEXT")
     private String foodPairing;
 
-    /**Поле description - описание напитка*/
+    /**
+     * Поле description - описание напитка
+     */
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    /**Поле rating - рейтинг*/
+    /**
+     * Поле rating - рейтинг
+     */
     @Setter
     @Column
     private Float rating;

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/domain/entity/ErrorOnSaving.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/domain/entity/ErrorOnSaving.java
@@ -17,109 +17,158 @@ import java.sql.Timestamp;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ErrorOnSaving {
-    
-    /**Поле id - уникальный номер*/
+
+    /**
+     * Поле id - уникальный номер
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /**Поле type - тип (Вино/Шампанское/Игристое)*/
+    /**
+     * Поле type - тип (Вино/Шампанское/Игристое)
+     */
     @Column(columnDefinition = "TEXT")
     private String type;
 
-    /**Поле name - название напитка*/
+    /**
+     * Поле name - название напитка
+     */
     @Column(columnDefinition = "TEXT")
     private String name;
 
-    /**Поле url - ссылка на страницу напитка*/
+    /**
+     * Поле url - ссылка на страницу напитка
+     */
     @Column(columnDefinition = "TEXT")
     private String url;
 
-    /**Поле imageUrl - ссылка на изображение напитка*/
+    /**
+     * Поле imageUrl - ссылка на изображение напитка
+     */
     @Column(columnDefinition = "TEXT")
     private String imageUrl;
 
-    /**Поле cropYear - год сбора*/
+    /**
+     * Поле cropYear - год сбора
+     */
     @Column(columnDefinition = "TEXT")
     private String cropYear;
 
-    /**Поле manufacturer - производитель*/
+    /**
+     * Поле manufacturer - производитель
+     */
     @Column(columnDefinition = "TEXT")
     private String manufacturer;
 
-    /**Поле brand - бренд*/
+    /**
+     * Поле brand - бренд
+     */
     @Column(columnDefinition = "TEXT")
     private String brand;
 
-    /**Поле color - оттенок*/
+    /**
+     * Поле color - оттенок
+     */
     @Column(columnDefinition = "TEXT")
     private String color;
 
-    /**Поле country - страна происхождения винограда*/
+    /**
+     * Поле country - страна происхождения винограда
+     */
     @Column(columnDefinition = "TEXT")
     private String country;
 
-    /**Поле region - регион винограда*/
+    /**
+     * Поле region - регион винограда
+     */
     @Column(columnDefinition = "TEXT")
     private String region;
 
-    /**Поле volume - обьем*/
+    /**
+     * Поле volume - обьем
+     */
     @Column(columnDefinition = "TEXT")
     private String volume;
 
-    /**Поле strength - крепость*/
+    /**
+     * Поле strength - крепость
+     */
     @Column(columnDefinition = "TEXT")
     private Float strength;
 
-    /**Поле isugar - сладость/сухость*/
+    /**
+     * Поле isugar - сладость/сухость
+     */
     @Column(columnDefinition = "TEXT")
     private String sugar;
 
-    /**Поле price - цена в рублях*/
+    /**
+     * Поле price - цена в рублях
+     */
     @Column(columnDefinition = "TEXT")
     private String price;
 
-    /**Поле grape - сорт винограда*/
+    /**
+     * Поле grape - сорт винограда
+     */
     @Column(columnDefinition = "TEXT")
     private String grape;
 
-    /**Поле taste - вкус*/
+    /**
+     * Поле taste - вкус
+     */
     @Column(columnDefinition = "TEXT")
     private String taste;
 
-    /**Поле aroma - аромат*/
+    /**
+     * Поле aroma - аромат
+     */
     @Column(columnDefinition = "TEXT")
     private String aroma;
 
-    /**Поле foodPairing - сочетания с блюдами*/
+    /**
+     * Поле foodPairing - сочетания с блюдами
+     */
     @Column(columnDefinition = "TEXT")
     private String foodPairing;
 
-    /**Поле description - описание напитка*/
+    /**
+     * Поле description - описание напитка
+     */
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    /**Поле rating - рейтинг*/
+    /**
+     * Поле rating - рейтинг
+     */
     @Column(columnDefinition = "TEXT")
     private String rating;
 
-    /**Поле unsavedId - id при попытки сохранения*/
+    /**
+     * Поле unsavedId - id при попытки сохранения
+     */
     @Column
     private Long unsavedId;
 
-    /**Поле timestamp - время попытки сохранения*/
+    /**
+     * Поле timestamp - время попытки сохранения
+     */
     @Column
     private Timestamp timestamp;
 
-    /**Поле error - текст ошибки при сохранении*/
+    /**
+     * Поле error - текст ошибки при сохранении
+     */
     @Column(columnDefinition = "TEXT")
     private String error;
 
     /**
      * Создание сущности ошибки.
-     * @param alcohol - сущность Алкоголя, при которой произошла ошибка.
+     *
+     * @param alcohol   - сущность Алкоголя, при которой произошла ошибка.
      * @param timestamp - время ошибки.
-     * @param error - описание ошибки.
+     * @param error     - описание ошибки.
      * @return ошибка при сохранении алкоголя.
      */
     public static ErrorOnSaving of(Alcohol alcohol, Timestamp timestamp, String error) {

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/Director.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/Director.java
@@ -3,9 +3,10 @@ package com.wine.to.up.winestyle.parser.service.service;
 import com.wine.to.up.parser.common.api.schema.ParserApi;
 import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.City;
 
 public interface Director {
-    Alcohol makeAlcohol(Parser parser, String mainPageUrl, String productUrl, AlcoholType alcoholType);
+    Alcohol makeAlcohol(Parser parser, String mainPageUrl, String productUrl, AlcoholType alcoholType, City city);
 
     ParserApi.Wine.Builder getKafkaMessageBuilder();
 

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/KafkaService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/KafkaService.java
@@ -1,7 +1,7 @@
 package com.wine.to.up.winestyle.parser.service.service;
 
 public interface KafkaService {
-    void sendAllalcohol();
+    void sendAllAlcohol();
     void sendAllWines();
     void sendAllSparkling();
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/Parser.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/Parser.java
@@ -37,6 +37,8 @@ public interface Parser {
 
     Optional<String> parseSugar();
 
+    Optional<Boolean> parseAvailability();
+
     Optional<String> parseTaste();
 
     Optional<String> parseAroma();

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/WinestyleParserService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/WinestyleParserService.java
@@ -1,11 +1,8 @@
 package com.wine.to.up.winestyle.parser.service.service;
 
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.City;
 
 public interface WinestyleParserService {
-    void parseBuildSave(String relativeUrl) throws InterruptedException;
-
-    void setAlcoholType(AlcoholType alcoholType);
-
-    void setMainPageUrl(String mainPageUrl);
+    void parseBuildSave(AlcoholType alcoholType, City city) throws InterruptedException;
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/controller/ParsingControllerService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/controller/ParsingControllerService.java
@@ -1,6 +1,5 @@
 package com.wine.to.up.winestyle.parser.service.service.implementation.controller;
 
-import com.google.common.collect.ImmutableMap;
 import com.wine.to.up.winestyle.parser.service.components.WinestyleParserServiceMetricsCollector;
 import com.wine.to.up.winestyle.parser.service.controller.exception.ServiceIsBusyException;
 import com.wine.to.up.winestyle.parser.service.domain.entity.Timing;
@@ -12,10 +11,8 @@ import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.en
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.ServiceType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
 import java.time.LocalDateTime;
 
 /**
@@ -29,30 +26,6 @@ public class ParsingControllerService {
     private final StatusService statusService;
     private final RepositoryService repositoryService;
 
-    @Value("${spring.jsoup.scraping.winestyle-main-msk-url}")
-    private String mskUrl;
-    @Value("${spring.jsoup.scraping.winestyle-main-spb-url}")
-    private String spbUrl;
-    @Value("${spring.jsoup.scraping.winestyle-wine-part-url}")
-    private String wineUrl;
-    @Value("${spring.jsoup.scraping.winestyle-sparkling-part-url}")
-    private String sparklingUrl;
-
-    private ImmutableMap<City, String> supportedCityUrls;
-    private ImmutableMap<AlcoholType, String> supportedAlcoholUrls;
-
-    @PostConstruct
-    private void populateUrl() {
-        supportedCityUrls = ImmutableMap.<City, String>builder()
-                .put(City.MSK, mskUrl)
-                .put(City.SPB, spbUrl)
-                .build();
-        supportedAlcoholUrls = ImmutableMap.<AlcoholType, String>builder()
-                .put(AlcoholType.WINE, wineUrl)
-                .put(AlcoholType.SPARKLING, sparklingUrl)
-                .build();
-    }
-
     // Start parsing job in a separate thread
     public void startParsingJob(City city, AlcoholType alcoholType) throws ServiceIsBusyException {
         if (statusService.tryBusy(ServiceType.PARSER)) {
@@ -61,7 +34,7 @@ public class ParsingControllerService {
             WinestyleParserServiceMetricsCollector.updateInProgress(1);
             new Thread(() -> {
                 try {
-                    alcoholParserService.parseBuildSave(supportedAlcoholUrls.get(alcoholType));
+                    alcoholParserService.parseBuildSave(alcoholType, city);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 } finally {

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/controller/ParsingControllerService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/controller/ParsingControllerService.java
@@ -60,8 +60,6 @@ public class ParsingControllerService {
             WinestyleParserServiceMetricsCollector.incParsingStarted();
             WinestyleParserServiceMetricsCollector.updateInProgress(1);
             new Thread(() -> {
-                alcoholParserService.setAlcoholType(alcoholType);
-                alcoholParserService.setMainPageUrl(supportedCityUrls.get(city));
                 try {
                     alcoholParserService.parseBuildSave(supportedAlcoholUrls.get(alcoholType));
                 } catch (InterruptedException e) {

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSender.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSender.java
@@ -1,0 +1,36 @@
+package com.wine.to.up.winestyle.parser.service.service.implementation.kafka;
+
+import com.wine.to.up.commonlib.messaging.KafkaMessageSender;
+import com.wine.to.up.parser.common.api.schema.ParserApi;
+import com.wine.to.up.winestyle.parser.service.components.WinestyleParserServiceMetricsCollector;
+import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
+import com.wine.to.up.winestyle.parser.service.service.Director;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KafkaSender {
+    private final KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
+    private final Director parserDirector;
+
+    private ParserApi.WineParsedEvent.Builder kafkaMessageBuilder = ParserApi.WineParsedEvent.newBuilder();
+    private Integer sended = 0;
+
+    public Integer sendAlcoholToKafka(Alcohol alcohol) {
+        try {
+            kafkaMessageSender.sendMessage(kafkaMessageBuilder
+                    .addWines(parserDirector
+                            .fillKafkaMessageBuilder(alcohol, AlcoholType.valueOf(alcohol.getType())))
+                    .build());
+            WinestyleParserServiceMetricsCollector.incPublished();
+            sended++;
+        } catch (Exception ex) {
+            log.error("Cannot send dataset to Kafka: id:{} {}", alcohol.getId(), alcohol.getType());
+        }
+        return sended;
+    }
+}

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSender.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSender.java
@@ -17,7 +17,7 @@ public class KafkaSender {
     private final KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
     private final Director parserDirector;
 
-    private ParserApi.WineParsedEvent.Builder kafkaMessageBuilder = ParserApi.WineParsedEvent.newBuilder();
+    private final ParserApi.WineParsedEvent.Builder kafkaMessageBuilder = ParserApi.WineParsedEvent.newBuilder();
     private Integer sended = 0;
 
     public Integer sendAlcoholToKafka(Alcohol alcohol) {

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderService.java
@@ -1,9 +1,5 @@
 package com.wine.to.up.winestyle.parser.service.service.implementation.kafka;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.wine.to.up.commonlib.messaging.KafkaMessageSender;
-import com.wine.to.up.parser.common.api.schema.ParserApi;
-import com.wine.to.up.winestyle.parser.service.components.WinestyleParserServiceMetricsCollector;
 import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
 import com.wine.to.up.winestyle.parser.service.service.Director;
 import com.wine.to.up.winestyle.parser.service.service.KafkaService;
@@ -11,120 +7,55 @@ import com.wine.to.up.winestyle.parser.service.service.RepositoryService;
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.*;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class KafkaSenderService implements KafkaService {
-    private final Director parserDirector;
     private final RepositoryService repositoryService;
-    private final KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
+    private final KafkaSender kafkaSender;
 
-    @Value("${spring.task.execution.pool.size}")
-    private int maxThreadCount;
-    @Value("${spring.jsoup.scraping.proxy-timeout.millis}")
-    private int timeout;
+    private Integer totalSended = 0;
 
-    private ExecutorService kafkaSendAllThreadPool;
-    private final ThreadFactory kafkaSendAllThreadFactory = new ThreadFactoryBuilder()
-            .setNameFormat("Kafka-Sender-%d")
-            .build();
-
-    private ExecutorService initPool(int maxThreadCount, ThreadFactory threadFactory) {
-        return Executors.newFixedThreadPool(maxThreadCount, threadFactory);
-    }
-
-    private void renewPools() {
-        if (kafkaSendAllThreadPool.isShutdown()) {
-            kafkaSendAllThreadPool = initPool(maxThreadCount, kafkaSendAllThreadFactory);
-        }
-    }
-
-    @PostConstruct
-    private void initPools() {
-        kafkaSendAllThreadPool = initPool(maxThreadCount, kafkaSendAllThreadFactory);
-    }
-
-    public void sendAllalcohol() {
-        renewPools();
+    public void sendAllAlcohol() {
         List<Alcohol> alcohol = repositoryService.getAll();
 
         LocalDateTime startSendingProcess = LocalDateTime.now();
         log.info("Start sending data of all alcohol to Kafka at {};", startSendingProcess);
 
-        int totalSended = 0;
-        try {
-            totalSended = sendalcohol(alcohol);
-        } catch (InterruptedException e) {
-            log.warn("The process of sending alcohol to kafka was interrupted!");
-        }
+        sendAlcohol(alcohol);
         logKafkaSended("alcohol", totalSended, startSendingProcess);
+        totalSended = 0;
     }
 
     public void sendAllWines() {
-        renewPools();
         List<Alcohol> wines = repositoryService.getAllWines();
 
         LocalDateTime startSendingProcess = LocalDateTime.now();
         log.info("Start sending data of all wines to Kafka at {};", startSendingProcess);
-
-        int totalSended = 0;
-        try {
-            totalSended = sendalcohol(wines);
-        } catch (InterruptedException e) {
-            log.warn("The process of sending wines to kafka was interrupted!");
-        }
+        sendAlcohol(wines);
         logKafkaSended(AlcoholType.WINE.toString(), totalSended, startSendingProcess);
+        totalSended = 0;
     }
 
     public void sendAllSparkling() {
-        renewPools();
         List<Alcohol> sparkling = repositoryService.getAllSparkling();
 
         LocalDateTime startSendingProcess = LocalDateTime.now();
         log.info("Start sending data of all sparkling to Kafka at {};", startSendingProcess);
 
-        int totalSended = 0;
-        try {
-            totalSended = sendalcohol(sparkling);
-        } catch (InterruptedException e) {
-            log.warn("The process of sending sparkling to kafka was interrupted!");
-        }
+        sendAlcohol(sparkling);
         logKafkaSended(AlcoholType.SPARKLING.toString(), totalSended, startSendingProcess);
+        totalSended = 0;
     }
 
-    private Integer sendalcohol(List<Alcohol> alcoholList) throws InterruptedException {
-        List<Future<Integer>> sendingFutures = new ArrayList<>();
-        Integer totalSended = 0;
-
-        try {
-            alcoholList.parallelStream().forEach(alcohol -> {
-                sendingFutures.add(kafkaSendAllThreadPool.submit(new KafkaSender(parserDirector, alcohol)));
-            });
-        } finally {
-            kafkaSendAllThreadPool.shutdown();
-            kafkaSendAllThreadPool.awaitTermination(timeout, TimeUnit.MILLISECONDS);
-
-            for (Future<Integer> future : sendingFutures) {
-                try {
-                    totalSended += future.get();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } catch (ExecutionException e) {
-                    log.error("Cannot execute sending alcohol to kafka");
-                }
-            }
-        }
-        return totalSended;
+    private void sendAlcohol(List<Alcohol> alcoholList) {
+        alcoholList.forEach(alcohol -> totalSended += kafkaSender.sendAlcoholToKafka(alcohol));
     }
 
     private void logKafkaSended(String alcoholType, Integer total, LocalDateTime startTime) {
@@ -139,33 +70,5 @@ public class KafkaSenderService implements KafkaService {
 
         log.info("Sending {} to kafka: in {} hours {} minutes {} seconds. Total sended {} alcohol",
                 alcoholType, hoursPassed, minutesPart, secondsPart, total);
-    }
-
-    @RequiredArgsConstructor
-    private class KafkaSender implements Callable<Integer> {
-        private final Director parserDirector;
-        private final Alcohol alcohol;
-
-        private ParserApi.WineParsedEvent.Builder kafkaMessageBuilder = ParserApi.WineParsedEvent.newBuilder();
-        private Integer sended = 0;
-
-        private Integer sendAlcoholToKafka() {
-            try {
-                kafkaMessageSender.sendMessage(kafkaMessageBuilder
-                        .addWines(parserDirector
-                                .fillKafkaMessageBuilder(alcohol, AlcoholType.valueOf(alcohol.getType())))
-                        .build());
-                WinestyleParserServiceMetricsCollector.incPublished();
-                sended++;
-            } catch (Exception ex) {
-                log.error("Cannot send dataset to Kafka: id:{} {}", alcohol.getId(), alcohol.getType());
-            }
-            return sended;
-        }
-
-        @Override
-        public Integer call() throws Exception {
-            return sendAlcoholToKafka();
-        }
     }
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderService.java
@@ -1,7 +1,6 @@
 package com.wine.to.up.winestyle.parser.service.service.implementation.kafka;
 
 import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
-import com.wine.to.up.winestyle.parser.service.service.Director;
 import com.wine.to.up.winestyle.parser.service.service.KafkaService;
 import com.wine.to.up.winestyle.parser.service.service.RepositoryService;
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
@@ -140,6 +140,14 @@ public class ParserDirector implements Director {
                 () -> entityBuilder.sugar(null)
         );
 
+        parser.parseAvailability().ifPresentOrElse(
+                value -> {
+                    entityBuilder.availability(value);
+                    kafkaMessageBuilder.setInStock(value ? 1 : 0);
+                },
+                () -> entityBuilder.availability(null)
+        );
+
         parser.parseTaste().ifPresentOrElse(
                 value -> {
                     entityBuilder.taste(value);
@@ -214,6 +222,8 @@ public class ParserDirector implements Director {
         Optional.ofNullable(source.getColor()).ifPresent(color -> kafkaMessageBuilder.setColor(matchColorToValue(color)));
 
         Optional.ofNullable(source.getSugar()).ifPresent(sugar -> kafkaMessageBuilder.setSugar(matchSugarToValue(sugar)));
+
+        Optional.ofNullable(source.getAvailability() ? 0 : 1).ifPresent(kafkaMessageBuilder::setInStock);
 
         Optional.ofNullable(source.getTaste()).ifPresent(kafkaMessageBuilder::setTaste);
 

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
@@ -5,6 +5,7 @@ import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
 import com.wine.to.up.winestyle.parser.service.service.Director;
 import com.wine.to.up.winestyle.parser.service.service.Parser;
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.City;
 import lombok.Getter;
 import org.springframework.stereotype.Service;
 
@@ -18,7 +19,7 @@ public class ParserDirector implements Director {
     private final ParserApi.Wine.Builder kafkaMessageBuilder = ParserApi.Wine.newBuilder();
 
     @Override
-    public Alcohol makeAlcohol(Parser parser, String mainPageUrl, String productUrl, AlcoholType alcoholType) {
+    public Alcohol makeAlcohol(Parser parser, String mainPageUrl, String productUrl, AlcoholType alcoholType, City city) {
         Alcohol.AlcoholBuilder entityBuilder = Alcohol.builder();
 
         String name = parser.parseName();
@@ -27,6 +28,9 @@ public class ParserDirector implements Director {
 
         entityBuilder.url(productUrl);
         kafkaMessageBuilder.setLink(productUrl);
+
+        entityBuilder.city(city);
+        kafkaMessageBuilder.setCity(city.toString());
 
         boolean isSparkling = alcoholType == AlcoholType.SPARKLING;
         entityBuilder.type(parser.parseType(isSparkling));
@@ -177,6 +181,8 @@ public class ParserDirector implements Director {
         kafkaMessageBuilder.setName(source.getName());
 
         kafkaMessageBuilder.setLink(source.getUrl());
+
+        kafkaMessageBuilder.setCity(source.getCity().toString());
 
         kafkaMessageBuilder.setSparkling(alcoholType == AlcoholType.SPARKLING);
 

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
@@ -55,6 +55,7 @@ public class ParserDirector implements Director {
         parser.parsePrice().ifPresentOrElse(
                 value -> {
                     entityBuilder.price(value);
+                    kafkaMessageBuilder.setOldPrice(value);
                     kafkaMessageBuilder.setNewPrice(value);
                 },
                 () -> entityBuilder.price(null)

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
@@ -223,7 +223,7 @@ public class ParserDirector implements Director {
 
         Optional.ofNullable(source.getSugar()).ifPresent(sugar -> kafkaMessageBuilder.setSugar(matchSugarToValue(sugar)));
 
-        Optional.ofNullable(source.getAvailability() ? 0 : 1).ifPresent(kafkaMessageBuilder::setInStock);
+        Optional.ofNullable(source.getAvailability()).ifPresent(availability -> kafkaMessageBuilder.setInStock(availability ? 1 : 0));
 
         Optional.ofNullable(source.getTaste()).ifPresent(kafkaMessageBuilder::setTaste);
 

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserDirector.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Optional;
 
-@Service
+@Service("ParserDirector")
 public class ParserDirector implements Director {
     @Getter
     private final ParserApi.Wine.Builder kafkaMessageBuilder = ParserApi.Wine.newBuilder();

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserService.java
@@ -2,47 +2,26 @@ package com.wine.to.up.winestyle.parser.service.service.implementation.parser;
 
 import com.wine.to.up.commonlib.annotations.InjectEventLogger;
 import com.wine.to.up.commonlib.logging.EventLogger;
-import com.wine.to.up.commonlib.messaging.KafkaMessageSender;
-import com.wine.to.up.parser.common.api.schema.ParserApi;
 import com.wine.to.up.winestyle.parser.service.components.WinestyleParserServiceMetricsCollector;
-import com.wine.to.up.winestyle.parser.service.controller.exception.NoEntityException;
-import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
 import com.wine.to.up.winestyle.parser.service.logging.NotableEvents;
-import com.wine.to.up.winestyle.parser.service.service.Director;
-import com.wine.to.up.winestyle.parser.service.service.Parser;
-import com.wine.to.up.winestyle.parser.service.service.RepositoryService;
 import com.wine.to.up.winestyle.parser.service.service.WinestyleParserService;
 import com.wine.to.up.winestyle.parser.service.service.implementation.document.Scraper;
-import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ApplicationContextLocator;
-import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.MainPageSegmentor;
-import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ProductBlockSegmentor;
-import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ProductPageSegmentor;
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import com.wine.to.up.winestyle.parser.service.service.implementation.parser.job.MainJob;
 import io.micrometer.core.annotation.Timed;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.time.DayOfWeek;
-import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Supplier;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ParserService implements WinestyleParserService {
-    private final KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
-    private final RepositoryService repositoryService;
+    private final MainJob mainJob;
     private final Scraper scraper;
 
     @Setter
@@ -52,16 +31,12 @@ public class ParserService implements WinestyleParserService {
 
     private static final String PARSING_PROCESS_DURATION_SUMMARY = "parsing_process_duration";
 
-    @Value("${spring.jsoup.scraping.interval.millis}")
-    private int timeout;
     @Value("${spring.jsoup.pagination.css.query.main-bottom}")
     private String paginationElementCssQuery;
 
     @SuppressWarnings("unused")
     @InjectEventLogger
     private EventLogger eventLogger;
-
-    private int parsed = 0;
 
     @Timed(PARSING_PROCESS_DURATION_SUMMARY)
     @Override
@@ -85,7 +60,7 @@ public class ParserService implements WinestyleParserService {
                 log.info("Parsing: {}", currentDoc.location());
 
                 try {
-                    Integer currentUnparsed = new MainJob(currentDoc, start, scraper).get();
+                    Integer currentUnparsed = mainJob.get(currentDoc, alcoholType, mainPageUrl, start);
                     unparsed += currentUnparsed;
                 }
                 catch (Exception e) {
@@ -108,7 +83,7 @@ public class ParserService implements WinestyleParserService {
 
             log.debug("Unparsed {}: {}", alcoholType, unparsed);
 
-            parsed = 0;
+            mainJob.setParsed(0);
         }
     }
 
@@ -118,180 +93,6 @@ public class ParserService implements WinestyleParserService {
         } catch (NullPointerException ex) {
             log.info("{} does not contain a pagination element: the number of pages is set to 1", doc.location());
             return 1;
-        }
-    }
-
-    @RequiredArgsConstructor
-    private class MainJob implements Supplier<Integer> {
-        private final Document currentDoc;
-        private final LocalDateTime start;
-        private final Scraper scraper;
-        private final MainPageSegmentor mainPageSegmentor = ApplicationContextLocator.getApplicationContext().getBean(MainPageSegmentor.class);
-
-        /**
-         * Парсер страницы с позициями
-         */
-        @SneakyThrows
-        @Override
-        public Integer get() {
-            LocalDateTime mainParsingStart = LocalDateTime.now();
-            Elements productElements = mainPageSegmentor.extractProductElements(currentDoc);
-
-            int parsedNow = 0;
-            int unparsed = 0;
-
-            List<Pair<ProductJob, String>> parsingJobs = new ArrayList<>();
-            ProductJob productJob;
-            String productUrl;
-
-            for (Element productElement : productElements) {
-                productJob = new ProductJob(productElement, scraper);
-                try {
-                    productUrl = productJob.new ProductUrlJob().get();
-                } catch (Exception e) {
-                    log.error("Critical error during execution of url from product block {}", productElement.html());
-                    continue;
-                }
-                parsingJobs.add(new Pair<>(productJob, productUrl));
-            }
-
-            Pair<ProductJob, String> currentPair;
-            Alcohol result;
-
-            for (int i = 0; i < productElements.size(); i++) {
-                currentPair = parsingJobs.get(i);
-                productUrl = currentPair.getUrl();
-                try {
-                    result = currentPair.getParsingJob().get();
-                    eventLogger.info(NotableEvents.I_WINE_DETAILS_PARSED, productUrl, result);
-                    parsedNow += 1;
-                } catch (Exception e) {
-                    eventLogger.warn(NotableEvents.W_WINE_DETAILS_PARSING_FAILED, productUrl);
-                    unparsed += 1;
-                }
-                Thread.sleep(timeout);
-            }
-
-            WinestyleParserServiceMetricsCollector.sumPageParsingDuration(mainParsingStart, LocalDateTime.now());
-
-            eventLogger.info(NotableEvents.I_WINE_PAGE_PARSED, currentDoc.location());
-
-            countParsed(parsedNow);
-
-            logParsed(alcoholType, start);
-
-            return unparsed;
-        }
-
-        private synchronized void countParsed(int parsedNow) {
-            parsed += parsedNow;
-        }
-
-        private void logParsed(AlcoholType alcoholType, LocalDateTime start) {
-            long hoursPassed;
-            long minutesPart;
-            long secondsPart;
-            Duration timePassed = java.time.Duration.between((start), LocalDateTime.now());
-
-            hoursPassed = timePassed.toHours();
-            minutesPart = (timePassed.toMinutes() - hoursPassed * 60);
-            secondsPart = (timePassed.toSeconds() - hoursPassed * 3600 - minutesPart * 60);
-
-            log.info("Parsing of {}: {} in {} hours {} minutes {} seconds ({} entities per second)",
-                    alcoholType, parsed, hoursPassed, minutesPart, secondsPart, parsed / (double) timePassed.toSeconds());
-        }
-
-        @RequiredArgsConstructor
-        private class Pair<L, R> {
-            @Getter
-            private final L parsingJob;
-            @Getter
-            private final R url;
-        }
-    }
-
-    @RequiredArgsConstructor
-    private class ProductJob implements Supplier<Alcohol> {
-        private final Element productElement;
-        private final Scraper scraper;
-        private final Director director = new ParserDirector();
-        private final ProductBlockSegmentor productBlockSegmentor = ApplicationContextLocator.getApplicationContext().getBean(ProductBlockSegmentor.class);
-        private final Parser parser = ApplicationContextLocator.getApplicationContext().getBean(Parser.class);
-        private String productUrl;
-
-        @Override
-        public Alcohol get() {
-            log.info("Now parsing url: {}", productUrl);
-
-            LocalDateTime productParsingStart = LocalDateTime.now();
-
-            Alcohol alcohol;
-            ParserApi.WineParsedEvent.Builder kafkaMessageBuilder = ParserApi.WineParsedEvent.newBuilder().setShopLink(mainPageUrl);
-
-            try {
-                alcohol = repositoryService.getByUrl(productUrl);
-
-                if (LocalDateTime.now().getDayOfWeek() == DayOfWeek.MONDAY) {
-                    alcohol = parseProduct(kafkaMessageBuilder);
-                } else {
-                    alcohol.setPrice(parser.parsePrice().orElse(null));
-                    alcohol.setRating(parser.parseWinestyleRating().orElse(null));
-                    repositoryService.add(alcohol);
-                    kafkaMessageSender.sendMessage(kafkaMessageBuilder.addWines(director.fillKafkaMessageBuilder(alcohol, alcoholType)).build());
-                }
-            } catch (NoEntityException ex) {
-                alcohol = parseProduct(kafkaMessageBuilder);
-            }
-
-            WinestyleParserServiceMetricsCollector.sumDetailsParsingDuration(productParsingStart, LocalDateTime.now());
-            WinestyleParserServiceMetricsCollector.incPublished();
-
-            return alcohol;
-        }
-
-        private Alcohol parseProduct(ParserApi.WineParsedEvent.Builder kafkaMessageBuilder) {
-            Document product = null;
-
-            LocalDateTime detailsFetchingStart = LocalDateTime.now();
-            try {
-                product = scraper.getJsoupDocument(mainPageUrl + productUrl);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            WinestyleParserServiceMetricsCollector.sumDetailsFetchingDuration(detailsFetchingStart, LocalDateTime.now());
-
-            prepareParsingService(product);
-
-            Alcohol alcohol = director.makeAlcohol(parser, mainPageUrl, productUrl, alcoholType);
-
-            repositoryService.add(alcohol);
-
-            kafkaMessageSender.sendMessage(kafkaMessageBuilder.addWines(director.getKafkaMessageBuilder()).build());
-
-            return alcohol;
-        }
-
-        private void prepareParsingService(Document doc) {
-            ProductPageSegmentor productPageSegmentor = ApplicationContextLocator.getApplicationContext().getBean(ProductPageSegmentor.class);
-
-            Element productPageMainContent = productPageSegmentor.extractProductPageMainContent(doc);
-
-            parser.setListDescription(productBlockSegmentor.extractListDescription(productElement));
-            parser.setLeftBlock(productPageSegmentor.extractLeftBlock(productPageMainContent));
-            parser.setArticlesBlock(productPageSegmentor.extractArticlesBlock(productPageMainContent));
-            parser.setDescriptionBlock(productPageSegmentor.extractDescriptionBlock(productPageMainContent));
-        }
-
-        @RequiredArgsConstructor
-        private class ProductUrlJob implements Supplier<String> {
-            @Override
-            public String get() {
-                parser.setProductBlock(productElement);
-                parser.setInfoContainer(productBlockSegmentor.extractInfoContainer(productElement));
-
-                productUrl = parser.parseUrl();
-                return productUrl;
-            }
         }
     }
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserService.java
@@ -10,7 +10,6 @@ import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.en
 import com.wine.to.up.winestyle.parser.service.service.implementation.parser.job.MainJob;
 import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,13 +23,8 @@ public class ParserService implements WinestyleParserService {
     private final MainJob mainJob;
     private final Scraper scraper;
 
-    @Setter
-    private AlcoholType alcoholType;
-    @Setter
-    private String mainPageUrl;
-
     private static final String PARSING_PROCESS_DURATION_SUMMARY = "parsing_process_duration";
-
+    
     @Value("${spring.jsoup.pagination.css.query.main-bottom}")
     private String paginationElementCssQuery;
 

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserService.java
@@ -85,10 +85,9 @@ public class ParserService implements WinestyleParserService {
                 log.info("Parsing: {}", currentDoc.location());
 
                 try {
-                    Integer currentUnparsed = mainJob.get(currentDoc, alcoholType, mainPageUrl, start);
+                    Integer currentUnparsed = mainJob.get(currentDoc, alcoholType, mainPageUrl, start, city);
                     unparsed += currentUnparsed;
-                }
-                catch (Exception e) {
+                } catch (Exception e) {
                     eventLogger.warn(NotableEvents.W_WINE_PAGE_PARSING_FAILED, alcoholUrl + "?page=" + (nextPageNumber - 1));
                     unparsed += 20;
                 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserService.java
@@ -61,8 +61,6 @@ public class ParserService implements WinestyleParserService {
     @InjectEventLogger
     private EventLogger eventLogger;
 
-    private final Scraper scraper;
-
     private int parsed = 0;
 
     @Timed(PARSING_PROCESS_DURATION_SUMMARY)

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/MainJob.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/MainJob.java
@@ -1,0 +1,101 @@
+package com.wine.to.up.winestyle.parser.service.service.implementation.parser.job;
+
+import com.wine.to.up.commonlib.annotations.InjectEventLogger;
+import com.wine.to.up.commonlib.logging.EventLogger;
+import com.wine.to.up.winestyle.parser.service.components.WinestyleParserServiceMetricsCollector;
+import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
+import com.wine.to.up.winestyle.parser.service.logging.NotableEvents;
+import com.wine.to.up.winestyle.parser.service.service.Parser;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.MainPageSegmentor;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class MainJob {
+    private final Parser parser;
+    private final ProductJob productJob;
+    private final ProductUrlJob productUrlJob;
+    private final MainPageSegmentor mainPageSegmentor;
+
+    @Value("${spring.jsoup.scraping.interval.millis}")
+    private int timeout;
+    @Setter
+    private int parsed = 0;
+
+    @SuppressWarnings("unused")
+    @InjectEventLogger
+    private EventLogger eventLogger;
+
+    /**
+     * Парсер страницы с позициями
+     */
+    @SneakyThrows
+    public Integer get(Document currentDoc, AlcoholType alcoholType, String mainPageUrl, LocalDateTime start) {
+        LocalDateTime mainParsingStart = LocalDateTime.now();
+        Elements productElements = mainPageSegmentor.extractProductElements(currentDoc);
+
+        int parsedNow = 0;
+        int unparsed = 0;
+
+        String productUrl;
+        Alcohol result;
+
+        for (Element productElement : productElements) {
+            try {
+                productUrl = productUrlJob.get(parser, productElement);
+                try {
+                    result = productJob.getParsedAlcohol(parser, mainPageUrl, productUrl, productElement, alcoholType);
+                    eventLogger.info(NotableEvents.I_WINE_DETAILS_PARSED, productUrl, result);
+                    parsedNow += 1;
+                } catch (Exception e) {
+                    eventLogger.warn(NotableEvents.W_WINE_DETAILS_PARSING_FAILED, productUrl);
+                    unparsed += 1;
+                }
+                Thread.sleep(timeout);
+            } catch (Exception e) {
+                log.error("Critical error during execution of url from product block {}", productElement.html());
+            }
+        }
+
+        WinestyleParserServiceMetricsCollector.sumPageParsingDuration(mainParsingStart, LocalDateTime.now());
+
+        eventLogger.info(NotableEvents.I_WINE_PAGE_PARSED, currentDoc.location());
+
+        countParsed(parsedNow);
+
+        logParsed(alcoholType, start);
+
+        return unparsed;
+    }
+
+    private synchronized void countParsed(int parsedNow) {
+        parsed += parsedNow;
+    }
+
+    private void logParsed(AlcoholType alcoholType, LocalDateTime start) {
+        long hoursPassed;
+        long minutesPart;
+        long secondsPart;
+        Duration timePassed = java.time.Duration.between((start), LocalDateTime.now());
+
+        hoursPassed = timePassed.toHours();
+        minutesPart = (timePassed.toMinutes() - hoursPassed * 60);
+        secondsPart = (timePassed.toSeconds() - hoursPassed * 3600 - minutesPart * 60);
+
+        log.info("Parsing of {}: {} in {} hours {} minutes {} seconds ({} entities per second)",
+                alcoholType, parsed, hoursPassed, minutesPart, secondsPart, parsed / (double) timePassed.toSeconds());
+    }
+}

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/MainJob.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/MainJob.java
@@ -8,6 +8,7 @@ import com.wine.to.up.winestyle.parser.service.logging.NotableEvents;
 import com.wine.to.up.winestyle.parser.service.service.Parser;
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.MainPageSegmentor;
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.City;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.SneakyThrows;
@@ -43,7 +44,7 @@ public class MainJob {
      * Парсер страницы с позициями
      */
     @SneakyThrows
-    public Integer get(Document currentDoc, AlcoholType alcoholType, String mainPageUrl, LocalDateTime start) {
+    public Integer get(Document currentDoc, AlcoholType alcoholType, String mainPageUrl, LocalDateTime start, City city) {
         LocalDateTime mainParsingStart = LocalDateTime.now();
         Elements productElements = mainPageSegmentor.extractProductElements(currentDoc);
 
@@ -57,7 +58,7 @@ public class MainJob {
             try {
                 productUrl = productUrlJob.get(parser, productElement);
                 try {
-                    result = productJob.getParsedAlcohol(parser, mainPageUrl, productUrl, productElement, alcoholType);
+                    result = productJob.getParsedAlcohol(parser, mainPageUrl, productUrl, productElement, alcoholType, city);
                     eventLogger.info(NotableEvents.I_WINE_DETAILS_PARSED, productUrl, result);
                     parsedNow += 1;
                 } catch (Exception e) {

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductJob.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductJob.java
@@ -1,0 +1,109 @@
+package com.wine.to.up.winestyle.parser.service.service.implementation.parser.job;
+
+import com.wine.to.up.commonlib.messaging.KafkaMessageSender;
+import com.wine.to.up.parser.common.api.schema.ParserApi;
+import com.wine.to.up.winestyle.parser.service.components.WinestyleParserServiceMetricsCollector;
+import com.wine.to.up.winestyle.parser.service.controller.exception.NoEntityException;
+import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
+import com.wine.to.up.winestyle.parser.service.service.Director;
+import com.wine.to.up.winestyle.parser.service.service.Parser;
+import com.wine.to.up.winestyle.parser.service.service.RepositoryService;
+import com.wine.to.up.winestyle.parser.service.service.implementation.document.Scraper;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ApplicationContextLocator;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ProductBlockSegmentor;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ProductPageSegmentor;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import com.wine.to.up.winestyle.parser.service.service.implementation.parser.ParserDirector;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ProductJob {
+    @Qualifier("ParserDirector") private final Director director;
+    private final KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
+    private final RepositoryService repositoryService;
+    private final Scraper scraper;
+    private final ProductBlockSegmentor productBlockSegmentor;
+    private final ProductPageSegmentor productPageSegmentor;
+
+    private String mainPageUrl;
+    private String productUrl;
+    private AlcoholType alcoholType;
+    private Parser parser;
+
+    public Alcohol getParsedAlcohol(Parser parser, String mainPageUrl, String productUrl, Element productElement, AlcoholType alcoholType) {
+        this.mainPageUrl = mainPageUrl;
+        this.productUrl = productUrl;
+        this.alcoholType = alcoholType;
+        this.parser = parser;
+
+        log.info("Now parsing url: {}", productUrl);
+
+        LocalDateTime productParsingStart = LocalDateTime.now();
+
+        Alcohol alcohol;
+        ParserApi.WineParsedEvent.Builder kafkaMessageBuilder = ParserApi.WineParsedEvent.newBuilder().setShopLink(mainPageUrl);
+
+        try {
+            alcohol = repositoryService.getByUrl(productUrl);
+
+            if (LocalDateTime.now().getDayOfWeek() == DayOfWeek.MONDAY) {
+                alcohol = parseProduct(productElement, kafkaMessageBuilder);
+            } else {
+                alcohol.setPrice(parser.parsePrice().orElse(null));
+                alcohol.setRating(parser.parseWinestyleRating().orElse(null));
+                repositoryService.add(alcohol);
+                kafkaMessageSender.sendMessage(kafkaMessageBuilder.addWines(director.fillKafkaMessageBuilder(alcohol, alcoholType)).build());
+            }
+        } catch (NoEntityException ex) {
+            alcohol = parseProduct(productElement, kafkaMessageBuilder);
+        }
+
+        WinestyleParserServiceMetricsCollector.sumDetailsParsingDuration(productParsingStart, LocalDateTime.now());
+        WinestyleParserServiceMetricsCollector.incPublished();
+
+        return alcohol;
+    }
+
+    private Alcohol parseProduct(Element productElement, ParserApi.WineParsedEvent.Builder kafkaMessageBuilder) {
+        Document product = null;
+
+        LocalDateTime detailsFetchingStart = LocalDateTime.now();
+        try {
+            product = scraper.getJsoupDocument(mainPageUrl + productUrl);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        WinestyleParserServiceMetricsCollector.sumDetailsFetchingDuration(detailsFetchingStart, LocalDateTime.now());
+
+        prepareParsingService(product, productElement);
+
+        Alcohol alcohol = director.makeAlcohol(parser, mainPageUrl, productUrl, alcoholType);
+
+        repositoryService.add(alcohol);
+
+        kafkaMessageSender.sendMessage(kafkaMessageBuilder.addWines(director.getKafkaMessageBuilder()).build());
+
+        return alcohol;
+    }
+
+    private void prepareParsingService(Document doc, Element productElement) {
+
+        Element productPageMainContent = productPageSegmentor.extractProductPageMainContent(doc);
+
+        parser.setListDescription(productBlockSegmentor.extractListDescription(productElement));
+        parser.setLeftBlock(productPageSegmentor.extractLeftBlock(productPageMainContent));
+        parser.setArticlesBlock(productPageSegmentor.extractArticlesBlock(productPageMainContent));
+        parser.setDescriptionBlock(productPageSegmentor.extractDescriptionBlock(productPageMainContent));
+    }
+}

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductJob.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductJob.java
@@ -75,7 +75,7 @@ public class ProductJob {
         return alcohol;
     }
 
-    private Alcohol parseProduct(Element productElement, ParserApi.WineParsedEvent.Builder kafkaMessageBuilder) {
+    private Alcohol parseProduct(Element productElement, ParserApi.WineParsedEvent.Builder kafkaMessageBuilder, City city) {
         Document product = null;
 
         LocalDateTime detailsFetchingStart = LocalDateTime.now();
@@ -88,7 +88,7 @@ public class ProductJob {
 
         prepareParsingService(product, productElement);
 
-        Alcohol alcohol = director.makeAlcohol(parser, mainPageUrl, productUrl, alcoholType);
+        Alcohol alcohol = director.makeAlcohol(parser, mainPageUrl, productUrl, alcoholType, city);
 
         repositoryService.add(alcohol);
 

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductUrlJob.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductUrlJob.java
@@ -1,0 +1,19 @@
+package com.wine.to.up.winestyle.parser.service.service.implementation.parser.job;
+
+import com.wine.to.up.winestyle.parser.service.service.Parser;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.ProductBlockSegmentor;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ProductUrlJob {
+    private final ProductBlockSegmentor productBlockSegmentor;
+
+    public String get(Parser parser, Element productElement) {
+        parser.setProductBlock(productElement);
+        parser.setInfoContainer(productBlockSegmentor.extractInfoContainer(productElement));
+        return parser.parseUrl();
+    }
+}

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/parsing/AlcoholParser.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/parsing/AlcoholParser.java
@@ -52,6 +52,8 @@ public class AlcoholParser implements Parser {
     private String grapeElementCssQuery;
     @Value("${spring.jsoup.parsing.css.query.type}")
     private String typeElementCssQuery;
+    @Value("${spring.jsoup.parsing.css.query.availability}")
+    private String availabilityElementCssQuery;
     @Value("${spring.jsoup.parsing.css.query.taste}")
     private String tasteElementCssQuery;
     @Value("${spring.jsoup.parsing.css.query.aroma}")
@@ -67,6 +69,8 @@ public class AlcoholParser implements Parser {
     private String imageUrlPropertyCssAttr;
     @Value("${spring.jsoup.parsing.css.attr.winestyle-rating}")
     private String winestyleRatingPropertyCssAttr;
+    @Value("${spring.jsoup.parsing.css.attr.availability}")
+    private String availabilityPropertyCssAttr;
 
     private String name;
     private String url;
@@ -379,6 +383,19 @@ public class AlcoholParser implements Parser {
         } else {
             log.warn("{}: product's sugar is not specified", url);
             isSugarPresented = true;
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<Boolean> parseAvailability() {
+        try {
+            Element availabilityElement = productBlock.selectFirst(availabilityElementCssQuery);
+            String availabilityAttr = availabilityElement.attr(availabilityPropertyCssAttr);
+            String availabilityValue = availabilityAttr.substring(availabilityAttr.length() - 1) ;
+            return Optional.of(availabilityValue.matches("[13]"));
+        } catch (Exception ex) {
+            log.warn("{}: product's in stock availability is not specified", url);
             return Optional.empty();
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,13 +70,15 @@ spring.jsoup.parsing.css.query.taste=span:contains(\u0412\u043a\u0443\u0441)
 spring.jsoup.parsing.css.query.aroma=span:contains(\u0410\u0440\u043e\u043c\u0430\u0442)
 spring.jsoup.parsing.css.query.food-pairing=span:contains(\u0413\u0430\u0441\u0442\u0440\u043e\u043d\u043e\u043c\u0438\u0447\u0435\u0441\u043a\u0438\u0435 \u0441\u043e\u0447\u0435\u0442\u0430\u043d\u0438\u044f)
 spring.jsoup.parsing.css.query.description=.description-block
+spring.jsoup.parsing.css.query.availability=[${spring.jsoup.parsing.css.attr.availability}]
 spring.jsoup.parsing.css.attr.name=data-prodname
 spring.jsoup.parsing.css.attr.image-url=href
+spring.jsoup.parsing.css.attr.availability=data-avail
 spring.jsoup.parsing.css.attr.winestyle-rating=content
 
 # segmenting css queries
 spring.jsoup.segmenting.css.query.main-page=.main-content
-spring.jsoup.segmenting.css.query.product-page=.main-content
+spring.jsoup.segmenting.css.query.product-page=.item-content
 spring.jsoup.segmenting.css.query.info=.info-container
 spring.jsoup.segmenting.css.query.list-description=.list-description
 spring.jsoup.segmenting.css.query.description-block=.articles-container.desc

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=winestyle-parser-service
-server.port=8765
+server.port=8080
 
 management.endpoints.web.exposure.include=prometheus
 management.endpoint.prometheus.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,8 +36,8 @@ spring.jsoup.connection.user-agent=Mozilla/5.0 (Windows NT 6.1; Win64; x64) \
 # winestyle urls
 spring.jsoup.scraping.winestyle-main-msk-url=https://winestyle.ru
 spring.jsoup.scraping.winestyle-main-spb-url=https://spb.winestyle.ru
-spring.jsoup.scraping.winestyle-wine-part-url=/wine/available_ll/
-spring.jsoup.scraping.winestyle-sparkling-part-url=/champagnes-and-sparkling/champagnes/sparkling/sparkling-blue/available_ll/
+spring.jsoup.scraping.winestyle-wine-part-url=/wine/all/
+spring.jsoup.scraping.winestyle-sparkling-part-url=/champagnes-and-sparkling/champagnes/sparkling/sparkling-blue_ll/
 
 # proxies main properties
 spring.jsoup.scraping.proxy.different.check.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=winestyle-parser-service
+server.port=8765
 
 management.endpoints.web.exposure.include=prometheus
 management.endpoint.prometheus.enabled=true
@@ -15,6 +16,9 @@ spring.kafka.consumer.group-id=wine.winestyle-parser-service
 
 # flyway properties - https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#data-migration-properties
 spring.flyway.baseline-on-migrate=true
+
+# eureka properties
+eureka.client.service-url.defaultZone=http://eureka-service:8080/eureka
 
 # scheduler properties
 spring.task.scheduling.pool.size=3

--- a/src/main/resources/db/migration/V1.1.2__city_column.sql
+++ b/src/main/resources/db/migration/V1.1.2__city_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE alcohol ADD city VARCHAR(20);

--- a/src/main/resources/db/migration/V1.1.3__availability_column.sql
+++ b/src/main/resources/db/migration/V1.1.3__availability_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE alcohol ADD availability BOOL;

--- a/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserServiceTest.java
+++ b/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserServiceTest.java
@@ -38,43 +38,19 @@ class ParserServiceTest {
     @MockBean
     private ApplicationContextLocator applicationContextLocator = mock(ApplicationContextLocator.class);
 
-    @Mock
-    ExecutorService mainPageParsingThreadPool;
-    @Spy
-    ExecutorService productPageParsingThreadPool;
-    @Spy
-    ExecutorService urlFetchingThreadPool;
-
-    ThreadFactory mainPageParsingThreadFactory = new ThreadFactoryBuilder()
-            .setNameFormat("Main_parser-%d")
-            .build();
-    ThreadFactory productPageParsingThreadFactory = new ThreadFactoryBuilder()
-            .setNameFormat("Prod_parser-%d")
-            .build();
-    ThreadFactory urlFetchingThreadFactory = new ThreadFactoryBuilder()
-            .setNameFormat("Url_fetching-%d")
-            .build();
-
     String htmlPage = "div id=\"CatalogPagingBottom\"" +
-            "<li>1</li>" +
+            "<li>2</li>" +
             "</div>";
 
     @BeforeEach
-    void setUp() throws InterruptedException, ExecutionException {
+    void setUp() throws InterruptedException {
         MockitoAnnotations.initMocks(this);
-        ReflectionTestUtils.setField(parserService, "maxThreadCount", 2);
         ReflectionTestUtils.setField(parserService, "timeout", 10);
         ReflectionTestUtils.setField(parserService, "paginationElementCssQuery", "#CatalogPagingBottom li:last-of-type");
 
-        mainPageParsingThreadPool = spy(ExecutorService.class);
-        productPageParsingThreadPool = spy(Executors.newFixedThreadPool(2, productPageParsingThreadFactory));
-        urlFetchingThreadPool = spy(Executors.newFixedThreadPool(2, urlFetchingThreadFactory));
-        ReflectionTestUtils.setField(parserService, "mainPageParsingThreadPool", mainPageParsingThreadPool);
-        ReflectionTestUtils.setField(parserService, "productPageParsingThreadPool", productPageParsingThreadPool);
-        ReflectionTestUtils.setField(parserService, "urlFetchingThreadPool", urlFetchingThreadPool);
-
         Document document = Jsoup.parse(htmlPage);
         Mockito.when(scraper.getJsoupDocument("test/test")).thenReturn(document);
+        Mockito.when(scraper.getJsoupDocument("test/test?page=2")).thenReturn(document);
     }
 
     @Test
@@ -86,7 +62,7 @@ class ParserServiceTest {
         } catch (NullPointerException ex) {
             log.warn("Cannot execute MainJob inner class. Ok.");
         }
-        Mockito.verify(mainPageParsingThreadPool, times(1)).shutdownNow();
+        Mockito.verify(scraper, times(1)).getJsoupDocument("test/test");
     }
 
     @Test

--- a/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserServiceTest.java
+++ b/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/ParserServiceTest.java
@@ -30,13 +30,7 @@ class ParserServiceTest {
     @InjectMocks
     private ParserService parserService;
     @Mock
-    private KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
-    @Mock
-    private RepositoryService repositoryService;
-    @Mock
     private Scraper scraper;
-    @MockBean
-    private ApplicationContextLocator applicationContextLocator = mock(ApplicationContextLocator.class);
 
     String htmlPage = "div id=\"CatalogPagingBottom\"" +
             "<li>2</li>" +
@@ -45,7 +39,6 @@ class ParserServiceTest {
     @BeforeEach
     void setUp() throws InterruptedException {
         MockitoAnnotations.initMocks(this);
-        ReflectionTestUtils.setField(parserService, "timeout", 10);
         ReflectionTestUtils.setField(parserService, "paginationElementCssQuery", "#CatalogPagingBottom li:last-of-type");
 
         Document document = Jsoup.parse(htmlPage);


### PR DESCRIPTION
- Empty metrics dashboard fix
- Migration to 0.2.5 commonapi version
- _city_ field kafka passing and adding city JSON-field to Alcohol entity returning from endpoints
- _in_stock_ field kafka passing and adding in_stock JSON-field to Alcohol entity returning from endpoints
- SQL migration files for _city_ and _in_stock_ columns
- Now links are pointing to all wines, not just those available