### PR TITLE
Sprint 19 posting to kafka

### DIFF
--- a/src/main/java/com/wine/to/up/winestyle/parser/service/ServiceApplication.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/ServiceApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
@@ -11,6 +12,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @ComponentScan("com.wine.to.up")
 @EnableSwagger2
 @EnableScheduling
+@EnableAsync
 @EnableDiscoveryClient
 public class ServiceApplication {
     public static void main(String[] args) {

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/controller/KafkaController.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/controller/KafkaController.java
@@ -1,31 +1,44 @@
 package com.wine.to.up.winestyle.parser.service.controller;
 
+import com.wine.to.up.winestyle.parser.service.controller.exception.ServiceIsBusyException;
 import com.wine.to.up.winestyle.parser.service.service.KafkaService;
+import com.wine.to.up.winestyle.parser.service.service.implementation.controller.KafkaSenderControllerService;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Контроллер, который позволяет начать отправку позиций алкоголя в Кафку.
+ */
 @RestController
-@RequestMapping("/winestyle/kafka")
+@RequestMapping("/winestyle/api/kafka")
 @Slf4j
 @RequiredArgsConstructor
 public class KafkaController {
-    private final KafkaService kafkaSenderService;
+    private final KafkaSenderControllerService kafkaSenderControllerService;
 
+    /**
+     * @return HTTP-статус 200(ОК) и сообщение о начале парсинга в теле ответа.
+     * @throws ServiceIsBusyException когда отправка уже запущена.
+     */
     @PostMapping("/alcohol")
-    public void sendAllalcoholToKafka() {
-        kafkaSenderService.sendAllAlcohol();
+    public String sendAllAlcoholToKafka() throws ServiceIsBusyException {
+        kafkaSenderControllerService.startSendingAlcohol();
+        return "Sending process of alcohol to kafka was successfully launched.";
     }
 
-    @PostMapping("/alcohol/wines")
-    public void sendAllWinesToKafka() {
-        kafkaSenderService.sendAllWines();
-    }
-
-    @PostMapping("/alcohol/sparkling")
-    public void sendAllSparklingToKafka() {
-        kafkaSenderService.sendAllSparkling();
+    /**
+     * @param type тип алкоголя для отправки (wine или sparkling).
+     * @return HTTP-статус 200(ОК) и сообщение о начале парсинга в теле ответа.
+     * @throws ServiceIsBusyException когда отправка уже запущена.
+     */
+    @PostMapping("/alcohol/{type}")
+    public String sendAllTypeAlcoholToKafka(@PathVariable AlcoholType type) throws ServiceIsBusyException {
+        kafkaSenderControllerService.startSendingAlcohol(type);
+        return String.format("Sending process of %s to kafka was successfully launched.", type.toString());
     }
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/KafkaService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/KafkaService.java
@@ -1,7 +1,8 @@
 package com.wine.to.up.winestyle.parser.service.service;
 
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+
 public interface KafkaService {
     void sendAllAlcohol();
-    void sendAllWines();
-    void sendAllSparkling();
+    void sendAllAlcohol(AlcoholType alcoholType);
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/controller/KafkaSenderControllerService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/controller/KafkaSenderControllerService.java
@@ -19,8 +19,11 @@ public class KafkaSenderControllerService {
     public void startSendingAlcohol() throws ServiceIsBusyException {
         if (statusService.tryBusy(ServiceType.KAFKASENDER)) {
             new Thread(() -> {
-                kafkaService.sendAllAlcohol();
-                statusService.release(ServiceType.KAFKASENDER);
+                try{
+                    kafkaService.sendAllAlcohol();
+                } finally {
+                    statusService.release(ServiceType.KAFKASENDER);
+                }
             }).start();
         } else {
             throw ServiceIsBusyException.createWith("Sending process alcohol to kafka in progress already");
@@ -30,8 +33,11 @@ public class KafkaSenderControllerService {
     public void startSendingAlcohol(AlcoholType alcoholType) throws ServiceIsBusyException {
         if (statusService.tryBusy(ServiceType.KAFKASENDER)) {
             new Thread(() -> {
-                kafkaService.sendAllAlcohol(alcoholType);
-                statusService.release(ServiceType.KAFKASENDER);
+                try {
+                    kafkaService.sendAllAlcohol(alcoholType);
+                } finally {
+                    statusService.release(ServiceType.KAFKASENDER);
+                }
             }).start();
         } else {
             throw ServiceIsBusyException.createWith("Sending process alcohol to kafka in progress already");

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/controller/KafkaSenderControllerService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/controller/KafkaSenderControllerService.java
@@ -1,0 +1,41 @@
+package com.wine.to.up.winestyle.parser.service.service.implementation.controller;
+
+import com.wine.to.up.winestyle.parser.service.controller.exception.ServiceIsBusyException;
+import com.wine.to.up.winestyle.parser.service.service.KafkaService;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.StatusService;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.ServiceType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaSenderControllerService {
+    private final StatusService statusService;
+    private final KafkaService kafkaService;
+
+    public void startSendingAlcohol() throws ServiceIsBusyException {
+        if (statusService.tryBusy(ServiceType.KAFKASENDER)) {
+            new Thread(() -> {
+                kafkaService.sendAllAlcohol();
+                statusService.release(ServiceType.KAFKASENDER);
+            }).start();
+        } else {
+            throw ServiceIsBusyException.createWith("Sending process alcohol to kafka in progress already");
+        }
+    }
+
+    public void startSendingAlcohol(AlcoholType alcoholType) throws ServiceIsBusyException {
+        if (statusService.tryBusy(ServiceType.KAFKASENDER)) {
+            new Thread(() -> {
+                kafkaService.sendAllAlcohol(alcoholType);
+                statusService.release(ServiceType.KAFKASENDER);
+            }).start();
+        } else {
+            throw ServiceIsBusyException.createWith("Sending process alcohol to kafka in progress already");
+        }
+    }
+
+}

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/helpers/StatusService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/helpers/StatusService.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class StatusService {
     private final AtomicBoolean isParserBusy = new AtomicBoolean(false);
     private final AtomicBoolean isProxyInitBusy = new AtomicBoolean(false);
+    private final AtomicBoolean isKafkaSenderInitBusy = new AtomicBoolean(false);
 
     @Value("${spring.status-service.type.exception}")
     private String unsupportedTypeMessage;
@@ -24,6 +25,9 @@ public class StatusService {
                 break;
             case PROXY:
                 isProxyInitBusy.set(false);
+                break;
+            case KAFKASENDER:
+                isKafkaSenderInitBusy.set(false);
                 break;
             default:
                 throw new IllegalArgumentException(unsupportedTypeMessage);
@@ -41,6 +45,8 @@ public class StatusService {
                 return isParserBusy.compareAndSet(false, true);
             case PROXY:
                 return isProxyInitBusy.compareAndSet(false, true);
+            case KAFKASENDER:
+                return isKafkaSenderInitBusy.compareAndSet(false, true);
             default:
                 throw new IllegalArgumentException(unsupportedTypeMessage);
         }
@@ -52,6 +58,8 @@ public class StatusService {
                 return isParserBusy.get();
             case PROXY:
                 return isProxyInitBusy.get();
+            case KAFKASENDER:
+                return isKafkaSenderInitBusy.get();
             default:
                 throw new IllegalArgumentException(unsupportedTypeMessage);
         }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/helpers/StatusService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/helpers/StatusService.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class StatusService {
     private final AtomicBoolean isParserBusy = new AtomicBoolean(false);
     private final AtomicBoolean isProxyInitBusy = new AtomicBoolean(false);
-    private final AtomicBoolean isKafkaSenderInitBusy = new AtomicBoolean(false);
+    private final AtomicBoolean isKafkaSendeerProcessBusy = new AtomicBoolean(false);
 
     @Value("${spring.status-service.type.exception}")
     private String unsupportedTypeMessage;
@@ -27,7 +27,7 @@ public class StatusService {
                 isProxyInitBusy.set(false);
                 break;
             case KAFKASENDER:
-                isKafkaSenderInitBusy.set(false);
+                isKafkaSendeerProcessBusy.set(false);
                 break;
             default:
                 throw new IllegalArgumentException(unsupportedTypeMessage);
@@ -46,7 +46,7 @@ public class StatusService {
             case PROXY:
                 return isProxyInitBusy.compareAndSet(false, true);
             case KAFKASENDER:
-                return isKafkaSenderInitBusy.compareAndSet(false, true);
+                return isKafkaSendeerProcessBusy.compareAndSet(false, true);
             default:
                 throw new IllegalArgumentException(unsupportedTypeMessage);
         }
@@ -59,7 +59,7 @@ public class StatusService {
             case PROXY:
                 return isProxyInitBusy.get();
             case KAFKASENDER:
-                return isKafkaSenderInitBusy.get();
+                return isKafkaSendeerProcessBusy.get();
             default:
                 throw new IllegalArgumentException(unsupportedTypeMessage);
         }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/helpers/enums/ServiceType.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/helpers/enums/ServiceType.java
@@ -2,5 +2,6 @@ package com.wine.to.up.winestyle.parser.service.service.implementation.helpers.e
 
 public enum ServiceType {
     PARSER,
-    PROXY
+    PROXY,
+    KAFKASENDER
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSender.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSender.java
@@ -10,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+/**
+ * Класс, осуществляющий отправку позиции алкоголя в кафку
+ */
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -20,6 +23,11 @@ public class KafkaSender {
     private final ParserApi.WineParsedEvent.Builder kafkaMessageBuilder = ParserApi.WineParsedEvent.newBuilder();
     private Integer sended = 0;
 
+    /**
+     * отправление алкоголя в Кафку
+     * @param alcohol
+     * @return отправленное количество алкоголя
+     */
     public Integer sendAlcoholToKafka(Alcohol alcohol) {
         try {
             kafkaMessageSender.sendMessage(kafkaMessageBuilder

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderService.java
@@ -22,16 +22,14 @@ public class KafkaSenderService implements KafkaService {
     private final RepositoryService repositoryService;
     private final KafkaSender kafkaSender;
 
-    private Integer totalSended = 0;
-
     /**
      * отправить алкоголь конкретного типа
      * @param alcoholType - тип алкоголя
      */
     public void sendAllAlcohol(AlcoholType alcoholType) {
-        if (AlcoholType.WINE.toString().equals(alcoholType.toString())) {
+        if (AlcoholType.WINE == alcoholType) {
             sendAllWines();
-        } else if (AlcoholType.SPARKLING.toString().equals(alcoholType.toString())) {
+        } else if (AlcoholType.SPARKLING == alcoholType) {
             sendAllSparkling();
         }
     }
@@ -45,9 +43,8 @@ public class KafkaSenderService implements KafkaService {
         LocalDateTime startSendingProcess = LocalDateTime.now();
         log.info("Start sending data of all alcohol to Kafka at {};", startSendingProcess);
 
-        sendAlcohol(alcohol);
+        int totalSended = sendAlcohol(alcohol);
         logKafkaSended("alcohol", totalSended, startSendingProcess);
-        totalSended = 0;
     }
 
     private void sendAllWines() {
@@ -55,9 +52,8 @@ public class KafkaSenderService implements KafkaService {
 
         LocalDateTime startSendingProcess = LocalDateTime.now();
         log.info("Start sending data of all wines to Kafka at {};", startSendingProcess);
-        sendAlcohol(wines);
+        int totalSended = sendAlcohol(wines);
         logKafkaSended(AlcoholType.WINE.toString(), totalSended, startSendingProcess);
-        totalSended = 0;
     }
 
     private void sendAllSparkling() {
@@ -66,13 +62,12 @@ public class KafkaSenderService implements KafkaService {
         LocalDateTime startSendingProcess = LocalDateTime.now();
         log.info("Start sending data of all sparkling to Kafka at {};", startSendingProcess);
 
-        sendAlcohol(sparkling);
+        int totalSended = sendAlcohol(sparkling);
         logKafkaSended(AlcoholType.SPARKLING.toString(), totalSended, startSendingProcess);
-        totalSended = 0;
     }
 
-    private void sendAlcohol(List<Alcohol> alcoholList) {
-        alcoholList.forEach(alcohol -> totalSended += kafkaSender.sendAlcoholToKafka(alcohol));
+    private int sendAlcohol(List<Alcohol> alcoholList) {
+        return alcoholList.stream().mapToInt(kafkaSender::sendAlcoholToKafka).sum();
     }
 
     private void logKafkaSended(String alcoholType, Integer total, LocalDateTime startTime) {

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderService.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderService.java
@@ -12,6 +12,9 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * Сервис, отвечающий за процесс отправки в кафку
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -21,6 +24,21 @@ public class KafkaSenderService implements KafkaService {
 
     private Integer totalSended = 0;
 
+    /**
+     * отправить алкоголь конкретного типа
+     * @param alcoholType - тип алкоголя
+     */
+    public void sendAllAlcohol(AlcoholType alcoholType) {
+        if (AlcoholType.WINE.toString().equals(alcoholType.toString())) {
+            sendAllWines();
+        } else if (AlcoholType.SPARKLING.toString().equals(alcoholType.toString())) {
+            sendAllSparkling();
+        }
+    }
+
+    /**
+     * отправить все позиции алкоголя
+     */
     public void sendAllAlcohol() {
         List<Alcohol> alcohol = repositoryService.getAll();
 
@@ -32,7 +50,7 @@ public class KafkaSenderService implements KafkaService {
         totalSended = 0;
     }
 
-    public void sendAllWines() {
+    private void sendAllWines() {
         List<Alcohol> wines = repositoryService.getAllWines();
 
         LocalDateTime startSendingProcess = LocalDateTime.now();
@@ -42,7 +60,7 @@ public class KafkaSenderService implements KafkaService {
         totalSended = 0;
     }
 
-    public void sendAllSparkling() {
+    private void sendAllSparkling() {
         List<Alcohol> sparkling = repositoryService.getAllSparkling();
 
         LocalDateTime startSendingProcess = LocalDateTime.now();

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductJob.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductJob.java
@@ -68,7 +68,6 @@ public class ProductJob {
         }
 
         WinestyleParserServiceMetricsCollector.sumDetailsParsingDuration(productParsingStart, LocalDateTime.now());
-        WinestyleParserServiceMetricsCollector.incPublished();
 
         return alcohol;
     }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductJob.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/parser/job/ProductJob.java
@@ -29,7 +29,6 @@ import java.time.LocalDateTime;
 public class ProductJob {
     @Qualifier("ParserDirector")
     private final Director director;
-    private final KafkaMessageSender<ParserApi.WineParsedEvent> kafkaMessageSender;
     private final RepositoryService repositoryService;
     private final Scraper scraper;
     private final ProductBlockSegmentor productBlockSegmentor;
@@ -63,7 +62,6 @@ public class ProductJob {
                 alcohol.setPrice(parser.parsePrice().orElse(null));
                 alcohol.setRating(parser.parseWinestyleRating().orElse(null));
                 repositoryService.add(alcohol);
-                kafkaMessageSender.sendMessage(kafkaMessageBuilder.addWines(director.fillKafkaMessageBuilder(alcohol, alcoholType)).build());
             }
         } catch (NoEntityException ex) {
             alcohol = parseProduct(productElement, kafkaMessageBuilder, city);
@@ -91,8 +89,6 @@ public class ProductJob {
         Alcohol alcohol = director.makeAlcohol(parser, mainPageUrl, productUrl, alcoholType, city);
 
         repositoryService.add(alcohol);
-
-        kafkaMessageSender.sendMessage(kafkaMessageBuilder.addWines(director.getKafkaMessageBuilder()).build());
 
         return alcohol;
     }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/AlcoholParsingScheduler.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/AlcoholParsingScheduler.java
@@ -6,6 +6,7 @@ import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.en
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.City;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -15,12 +16,15 @@ import org.springframework.stereotype.Component;
 public class AlcoholParsingScheduler {
     private final ParsingControllerService parsingControllerService;
 
+    @Value("${spring.task.scheduling.rate.parser.delay}")
+    private int timeout;
+
     @Scheduled(cron = "${spring.task.scheduling.rate.parser.cron}", zone = "EAT")
     public void onScheduleParseAlcoholSpbWine() throws InterruptedException {
         try {
             parsingControllerService.startParsingJob(City.SPB, AlcoholType.WINE);
         } catch (ServiceIsBusyException e) {
-            Thread.sleep(3600000);
+            Thread.sleep(timeout);
             onScheduleParseAlcoholSpbWine();
         }
     }
@@ -30,7 +34,7 @@ public class AlcoholParsingScheduler {
         try {
             parsingControllerService.startParsingJob(City.SPB, AlcoholType.SPARKLING);
         } catch (ServiceIsBusyException e) {
-            Thread.sleep(3600000);
+            Thread.sleep(timeout);
             onScheduleParseAlcoholSpbSparkling();
         }
     }
@@ -40,7 +44,7 @@ public class AlcoholParsingScheduler {
         try {
             parsingControllerService.startParsingJob(City.MSK, AlcoholType.WINE);
         } catch (ServiceIsBusyException e) {
-            Thread.sleep(3600000);
+            Thread.sleep(timeout);
             onScheduleParseAlcoholMskWine();
         }
     }
@@ -50,7 +54,7 @@ public class AlcoholParsingScheduler {
         try {
             parsingControllerService.startParsingJob(City.MSK, AlcoholType.SPARKLING);
         } catch (ServiceIsBusyException e) {
-            Thread.sleep(3600000);
+            Thread.sleep(timeout);
             onScheduleParseAlcoholMskSparkling();
         }
     }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/AlcoholParsingScheduler.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/AlcoholParsingScheduler.java
@@ -1,13 +1,11 @@
 package com.wine.to.up.winestyle.parser.service.service.implementation.scheduling;
 
 import com.wine.to.up.winestyle.parser.service.controller.exception.ServiceIsBusyException;
-import com.wine.to.up.winestyle.parser.service.service.implementation.controller.MainControllerService;
 import com.wine.to.up.winestyle.parser.service.service.implementation.controller.ParsingControllerService;
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
 import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.City;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -16,37 +14,44 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class AlcoholParsingScheduler {
     private final ParsingControllerService parsingControllerService;
-    private final MainControllerService mainControllerService;
-
-    @Value("${spring.jsoup.connection.timeout.millis}")
-    private int timeout;
 
     @Scheduled(cron = "${spring.task.scheduling.rate.parser.cron}", zone = "EAT")
-    public void onScheduleParseWine() throws InterruptedException {
+    public void onScheduleParseAlcoholSpbWine() throws InterruptedException {
         try {
             parsingControllerService.startParsingJob(City.SPB, AlcoholType.WINE);
         } catch (ServiceIsBusyException e) {
             Thread.sleep(3600000);
-            onScheduleParseWine();
+            onScheduleParseAlcoholSpbWine();
         }
     }
 
     @Scheduled(cron = "${spring.task.scheduling.rate.parser.cron}", zone = "EAT")
-    public void onScheduleParseSparkling() throws InterruptedException {
+    public void onScheduleParseAlcoholSpbSparkling() throws InterruptedException {
         try {
             parsingControllerService.startParsingJob(City.SPB, AlcoholType.SPARKLING);
         } catch (ServiceIsBusyException e) {
             Thread.sleep(3600000);
-            onScheduleParseSparkling();
+            onScheduleParseAlcoholSpbSparkling();
         }
     }
 
-    //@Scheduled(fixedRateString = "${spring.task.scheduling.rate.proxy.fixed.millis}")
-    public void onScheduleLoadProxies() {
+    @Scheduled(cron = "${spring.task.scheduling.rate.parser.cron}", zone = "EAT")
+    public void onScheduleParseAlcoholMskWine() throws InterruptedException {
         try {
-            mainControllerService.startProxiesInitJob(timeout);
+            parsingControllerService.startParsingJob(City.MSK, AlcoholType.WINE);
         } catch (ServiceIsBusyException e) {
-            log.info("Scheduled proxy initialization job is rejected. {}", e.getMessage());
+            Thread.sleep(3600000);
+            onScheduleParseAlcoholMskWine();
+        }
+    }
+
+    @Scheduled(cron = "${spring.task.scheduling.rate.parser.cron}", zone = "EAT")
+    public void onScheduleParseAlcoholMskSparkling() throws InterruptedException {
+        try {
+            parsingControllerService.startParsingJob(City.MSK, AlcoholType.SPARKLING);
+        } catch (ServiceIsBusyException e) {
+            Thread.sleep(3600000);
+            onScheduleParseAlcoholMskSparkling();
         }
     }
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/KafkaSenderScheduler.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/KafkaSenderScheduler.java
@@ -1,6 +1,7 @@
 package com.wine.to.up.winestyle.parser.service.service.implementation.scheduling;
 
-import com.wine.to.up.winestyle.parser.service.service.KafkaService;
+import com.wine.to.up.winestyle.parser.service.controller.exception.ServiceIsBusyException;
+import com.wine.to.up.winestyle.parser.service.service.implementation.controller.KafkaSenderControllerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -13,11 +14,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 public class KafkaSenderScheduler {
-    private final KafkaService kafkaService;
+    private final KafkaSenderControllerService kafkaSenderControllerService;
 
     @Async
-    @Scheduled(fixedRateString = "${spring.task.scheduling.rate.auxiliary.fixed.millis}")
+    @Scheduled(fixedDelayString = "${spring.task.scheduling.rate.auxiliary.fixed.millis}")
     public void onScheduleSendAlcoholKafka() {
-        kafkaService.sendAllWines();
+        try {
+            kafkaSenderControllerService.startSendingAlcohol();
+        } catch (ServiceIsBusyException ignored) {
+
+        }
     }
 }

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/KafkaSenderScheduler.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/KafkaSenderScheduler.java
@@ -5,12 +5,10 @@ import com.wine.to.up.winestyle.parser.service.service.implementation.controller
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-@EnableAsync
 @RequiredArgsConstructor
 @Slf4j
 public class KafkaSenderScheduler {

--- a/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/KafkaSenderScheduler.java
+++ b/src/main/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/KafkaSenderScheduler.java
@@ -1,0 +1,23 @@
+package com.wine.to.up.winestyle.parser.service.service.implementation.scheduling;
+
+import com.wine.to.up.winestyle.parser.service.service.KafkaService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableAsync
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaSenderScheduler {
+    private final KafkaService kafkaService;
+
+    @Async
+    @Scheduled(fixedRateString = "${spring.task.scheduling.rate.auxiliary.fixed.millis}")
+    public void onScheduleSendAlcoholKafka() {
+        kafkaService.sendAllWines();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,7 @@ eureka.client.service-url.defaultZone=http://eureka-service:8080/eureka
 spring.task.scheduling.pool.size=3
 spring.task.scheduling.rate.parser.cron=0 0 0 * * *
 spring.task.scheduling.rate.proxy.fixed.millis=7200000
+spring.task.scheduling.rate.parser.delay=7200000
 spring.task.scheduling.rate.auxiliary.fixed.millis=300000
 
 # parser main properties

--- a/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderServiceTest.java
+++ b/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/kafka/KafkaSenderServiceTest.java
@@ -2,6 +2,7 @@ package com.wine.to.up.winestyle.parser.service.service.implementation.kafka;
 
 import com.wine.to.up.winestyle.parser.service.domain.entity.Alcohol;
 import com.wine.to.up.winestyle.parser.service.service.RepositoryService;
+import com.wine.to.up.winestyle.parser.service.service.implementation.helpers.enums.AlcoholType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
@@ -43,7 +44,6 @@ class KafkaSenderServiceTest {
 
         Future<Integer> future = mock(Future.class);
         Mockito.when(future.get()).thenReturn(1);
-
     }
 
     @Test
@@ -54,13 +54,13 @@ class KafkaSenderServiceTest {
 
     @Test
     void sendAllWines() {
-        kafkaSenderService.sendAllWines();
+        kafkaSenderService.sendAllAlcohol(AlcoholType.WINE);
         Mockito.verify(repositoryService, times(1)).getAllWines();
     }
 
     @Test
     void sendAllSparkling() {
-        kafkaSenderService.sendAllSparkling();
+        kafkaSenderService.sendAllAlcohol(AlcoholType.SPARKLING);
         Mockito.verify(repositoryService, times(1)).getAllSparkling();
     }
 }

--- a/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/AlcoholParsingSchedulerTest.java
+++ b/src/test/java/com/wine/to/up/winestyle/parser/service/service/implementation/scheduling/AlcoholParsingSchedulerTest.java
@@ -19,8 +19,6 @@ class AlcoholParsingSchedulerTest {
     private AlcoholParsingScheduler alcoholParsingScheduler;
     @Mock
     private ParsingControllerService parsingControllerService;
-    @Mock
-    private MainControllerService mainControllerService;
 
     @BeforeEach
     void setUp() {
@@ -28,10 +26,10 @@ class AlcoholParsingSchedulerTest {
     }
 
     @Test
-    void onScheduleParseWine() {
+    void onScheduleParseSpbWine() {
         try {
             Mockito.doNothing().when(parsingControllerService).startParsingJob(City.SPB, AlcoholType.WINE);
-            alcoholParsingScheduler.onScheduleParseWine();
+            alcoholParsingScheduler.onScheduleParseAlcoholSpbWine();
             Mockito.verify(parsingControllerService, Mockito.times(1))
                     .startParsingJob(City.SPB, AlcoholType.WINE);
         } catch (InterruptedException | ServiceIsBusyException e) {
@@ -40,10 +38,22 @@ class AlcoholParsingSchedulerTest {
     }
 
     @Test
-    void onScheduleParseSparkling() {
+    void onScheduleParseMskWine() {
+        try {
+            Mockito.doNothing().when(parsingControllerService).startParsingJob(City.MSK, AlcoholType.WINE);
+            alcoholParsingScheduler.onScheduleParseAlcoholMskWine();
+            Mockito.verify(parsingControllerService, Mockito.times(1))
+                    .startParsingJob(City.MSK, AlcoholType.WINE);
+        } catch (InterruptedException | ServiceIsBusyException e) {
+            fail("Test failed!", e);
+        }
+    }
+
+    @Test
+    void onScheduleParseSpbSparkling() {
         try {
             Mockito.doNothing().when(parsingControllerService).startParsingJob(City.SPB, AlcoholType.SPARKLING);
-            alcoholParsingScheduler.onScheduleParseSparkling();
+            alcoholParsingScheduler.onScheduleParseAlcoholSpbSparkling();
             Mockito.verify(parsingControllerService, Mockito.times(1))
                     .startParsingJob(City.SPB, AlcoholType.SPARKLING);
         } catch (InterruptedException | ServiceIsBusyException e) {
@@ -52,11 +62,13 @@ class AlcoholParsingSchedulerTest {
     }
 
     @Test
-    void onScheduleLoadProxies() {
+    void onScheduleParseMskSparkling() {
         try {
-            Mockito.doNothing().when(mainControllerService).startProxiesInitJob(1);
-            alcoholParsingScheduler.onScheduleLoadProxies();
-        } catch (ServiceIsBusyException e) {
+            Mockito.doNothing().when(parsingControllerService).startParsingJob(City.MSK, AlcoholType.SPARKLING);
+            alcoholParsingScheduler.onScheduleParseAlcoholMskSparkling();
+            Mockito.verify(parsingControllerService, Mockito.times(1))
+                    .startParsingJob(City.MSK, AlcoholType.SPARKLING);
+        } catch (InterruptedException | ServiceIsBusyException e) {
             fail("Test failed!", e);
         }
     }


### PR DESCRIPTION
Рефакторинг процесса запроса отправки сообщений (полей alcohol) из Rest-контроллера:

- Теперь поток Rest-клиента освобождается при старте отправки сообщений в Кафку
- Пользователь получает сообщение о старте

 
  Добавлен планировщик для асинхронной от парсера отправки сообщений в Кафку
  Добавлен планировщик для парсинга Москвы